### PR TITLE
Fix for Profile Options not Fully Merging

### DIFF
--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -87,36 +87,41 @@ def parse_profile(name, contents):
         # parse_profile, for example
         data = dict(_EMPTY_DATA)
     else:
-        data = _merge_dict(_EMPTY_DATA, data, dict1_priority=False)
+        data = _merge_dict(_EMPTY_DATA, data)
     return StrictnessProfile(name, data)
 
 
-def _merge_dict(dict1, dict2, dedup_lists=False, dict1_priority=True):
+def _merge_dict(dict1, dict2):
     newdict = {}
     newdict.update(dict1)
 
     for key, value in dict2.items():
         if key not in dict1:
             newdict[key] = value
-        elif value is None and dict1[key] is not None:
-            newdict[key] = dict1[key]
-        elif dict1[key] is None and value is not None:
+
+        elif dict1[key] is None:
             newdict[key] = value
+
+        elif value is None:
+            # Don't blast away existing values with None
+            pass
+
         elif type(value) != type(dict1[key]):
             raise ValueError("Could not merge conflicting types %s and %s" % (
                 type(value),
                 type(dict1[key]),
             ))
+
         elif isinstance(value, dict):
             newdict[key] = _merge_dict(
                 dict1[key],
                 value,
-                dedup_lists,
-                dict1_priority,
             )
+
         elif isinstance(value, (list, tuple)):
             newdict[key] = list(set(dict1[key]) | set(value))
-        elif not dict1_priority:
+
+        else:
             newdict[key] = value
 
     return newdict

--- a/tests/profiles/profiles/mergeoptions.yaml
+++ b/tests/profiles/profiles/mergeoptions.yaml
@@ -1,0 +1,5 @@
+pylint:
+  options:
+    max-public-methods: 30
+    max-attributes: 10
+

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -94,17 +94,5 @@ class TestProfileParsing(TestCase):
                 'c': 4
             }
         }
-        self.assertEqual(expected, _merge_dict(a, b, dedup_lists=True, dict1_priority=False))
+        self.assertEqual(expected, _merge_dict(a, b))
 
-        expected = {
-            'int': 1,
-            'str': 'fish',
-            'bool': True,
-            'list': [1, 2, 3],
-            'dict': {
-                'a': 1,
-                'b': 2,
-                'c': 4
-            }
-        }
-        self.assertEqual(expected, _merge_dict(a, b, dedup_lists=True, dict1_priority=True))

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -48,6 +48,25 @@ class TestProfileParsing(TestCase):
         expected = ['C1000', 'C1001', 'E0504', 'W1010', 'W1012']
         self.assertEqual(expected, merged_disabled_warnings)
 
+    def test_options_merge(self):
+        base_profile = from_file('strictness_veryhigh')
+
+        # These are the default settings.
+        self.assertEqual(base_profile.pylint['options']['max-public-methods'], 20)
+        self.assertEqual(base_profile.pylint['options']['max-attributes'], 7)
+
+        custom_profile = from_file('mergeoptions', self._basedir)
+
+        # These are what we're trying to set with a custom profile.
+        self.assertEqual(custom_profile.pylint['options']['max-public-methods'], 30)
+        self.assertEqual(custom_profile.pylint['options']['max-attributes'], 10)
+
+        merged_profile = merge_profiles((base_profile, custom_profile))
+
+        # The final, merged profile should have our custom options.
+        self.assertEqual(merged_profile.pylint['options']['max-public-methods'], 30)
+        self.assertEqual(merged_profile.pylint['options']['max-attributes'], 10)
+
     def test_ignores(self):
         profile = load_profiles('ignores', basedir=self._basedir)
         self.assertEqual(['^tests/', '/migrations/'].sort(), profile.ignore.sort())


### PR DESCRIPTION
When setting up custom profile.yaml files for my projects, I found that the options I was setting for pylint weren't being respected. After some digging, I found that the merging functionality didn't seem to do what it needed to do in order to carry my options over.

The tests around profiles and merging still pass (after modifying one due to removing some functionality in _merge_dict), and my custom profiles are now working as expected. But, you may want to poke at this a bit more to see if I missed something.