### PR TITLE
Add support for multiple positional path arguments

### DIFF
--- a/prospector/config.py
+++ b/prospector/config.py
@@ -263,7 +263,8 @@ def build_command_line_source(prog=None, description='Performs static analysis o
     positional = (
         ('checkpath', {
             'help': 'The path to a Python project to inspect. Defaults to PWD'
-                    '  if not specified.',
+                    '  if not specified. If multiple paths are specified,'
+                    '  they must all be files (no directories).',
             'metavar': 'PATH',
             'nargs': '*',
         }),

--- a/prospector/formatters/text.py
+++ b/prospector/formatters/text.py
@@ -11,6 +11,7 @@ __all__ = (
 
 class TextFormatter(Formatter):
     summary_labels = (
+        ('path', 'Path'),
         ('started', 'Started'),
         ('completed', 'Finished'),
         ('time_taken', 'Time Taken', lambda x: '%s seconds' % x),

--- a/prospector/run.py
+++ b/prospector/run.py
@@ -315,10 +315,15 @@ def main():
     else:
         paths = [os.getcwd()]
 
+    if len(paths) > 1 and not all([os.path.isfile(path) for path in paths]):
+        raise ValueError('In multi-path mode, all inputs must be files, '
+                         'not directories.')
+
     # Make it so
-    prospector = Prospector(config, paths[0])
-    prospector.execute()
-    prospector.print_messages()
+    for path in paths:
+        prospector = Prospector(config, path)
+        prospector.execute()
+        prospector.print_messages()
 
     if config.zero_exit:
         # if we ran successfully, and the user wants us to, then we'll

--- a/prospector/run.py
+++ b/prospector/run.py
@@ -204,6 +204,7 @@ class Prospector(object):
     def execute(self):
 
         summary = {
+            'path': self.path,
             'started': datetime.now(),
             'libraries': self.libraries,
             'strictness': self.strictness,
@@ -284,10 +285,12 @@ class Prospector(object):
         self.summary['formatter'] = output_format
         formatter = FORMATTERS[output_format](self.summary, self.messages)
 
+        print_messages = not self.config.summary_only and self.messages
+
         # Produce the output
         write_to.write(formatter.render(
             summary=not self.config.messages_only,
-            messages=not self.config.summary_only,
+            messages=print_messages,
         ))
         write_to.write('\n')
 
@@ -320,10 +323,12 @@ def main():
                          'not directories.')
 
     # Make it so
+    messages = []
     for path in paths:
         prospector = Prospector(config, path)
         prospector.execute()
         prospector.print_messages()
+        messages.extend(prospector.get_messages())
 
     if config.zero_exit:
         # if we ran successfully, and the user wants us to, then we'll
@@ -333,7 +338,7 @@ def main():
     # otherwise, finding messages is grounds for exiting with an error
     # code, to make it easier for bash scripts and similar situations
     # to know if there any errors have been found.
-    if len(prospector.get_messages()) > 0:
+    if len(messages) > 0:
         return 1
     return 0
 


### PR DESCRIPTION
This replaces #68. Instead of modifying `Prospector` to support multiple paths, I've modified `prospector.run.main` to create a new `Prospector` instance for each input path. 

Detailed changes:
* If more than one path is provided and one of the paths is a directory, raise a `ValueError`
* Explain multi-input directory restriction in `--help`
* Add `Path` to each summary
* Don't print `Messages` header if there are no messages