### PR TITLE
Correctly formatting character in 'text' outputter

### DIFF
--- a/prospector/formatters/text.py
+++ b/prospector/formatters/text.py
@@ -62,7 +62,7 @@ class TextFormatter(Formatter):
         output.append(
             '    L%s:%s %s: %s - %s' % (
                 message.location.line or '-',
-                message.location.character if message.location.line else '-',
+                message.location.character if message.location.character else '-',
                 message.location.function,
                 message.source,
                 message.code,


### PR DESCRIPTION
If the character is not specified, the character output by the (default) 'text' formatter should not default to '0' but instead represent that no character was specified.