### PR TITLE
Prospector-provided profiles should only be loaded if a profile is not provided by the user

### DIFF
--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -74,15 +74,6 @@ class ProspectorConfig(object):
         # Use other specialty profiles based on options
         profile_names = []
 
-        if not config.doc_warnings:
-            profile_names.append('no_doc_warnings')
-        if not config.test_warnings:
-            profile_names.append('no_test_warnings')
-        if not config.style_warnings:
-            profile_names.append('no_pep8')
-        if config.full_pep8:
-            profile_names.append('full_pep8')
-
         # Use the specified profiles
         profile_provided = False
         if len(config.profiles) > 0:
@@ -107,6 +98,16 @@ class ProspectorConfig(object):
         strictness = None
 
         if not profile_provided:
+            # Use the preconfigured prospector profiles
+            if not config.doc_warnings:
+                profile_names.append('no_doc_warnings')
+            if not config.test_warnings:
+                profile_names.append('no_test_warnings')
+            if not config.style_warnings:
+                profile_names.append('no_pep8')
+            if config.full_pep8:
+                profile_names.append('full_pep8')
+
             # Use the strictness profile only if no profile has been given
             if config.strictness:
                 profile_names = ['strictness_%s' % config.strictness] + profile_names
@@ -127,7 +128,7 @@ class ProspectorConfig(object):
 
         profile_path.append(path)
 
-        provided = os.path.join(os.path.dirname(__file__), '../profiles/profiles')
+        provided = os.path.abspath(os.path.join(os.path.dirname(__file__), '../profiles/profiles'))
         profile_path.append(provided)
 
         try:
@@ -154,7 +155,6 @@ class ProspectorConfig(object):
         return libraries
 
     def _determine_tool_runners(self, config, profile):
-
         if config.tools is None:
             # we had no command line settings for an explicit list of
             # tools, so we use the defaults

--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -29,6 +29,11 @@ for toolname in TOOLS.keys():
     }
 
 
+def _is_valid_extension(filename):
+    ext = os.path.splitext(filename)[1]
+    return ext in ('.yml', '.yaml')
+
+
 def load_profiles(names, profile_path):
     if not isinstance(names, (list, tuple)):
         names = (names,)
@@ -37,15 +42,19 @@ def load_profiles(names, profile_path):
 
 
 def _load_content(name, profile_path):
-    if name.endswith('.yaml') or name.endswith('.yml'):
+    if _is_valid_extension(name):
         # assume that this is a full path that we can load
         filename = name
     else:
+        filename = None
         for path in profile_path:
-            filename = os.path.join(path, '%s.yaml' % name)
-            if os.path.exists(filename):
-                break
-        else:
+            for ext in ('yml', 'yaml'):
+                filepath = os.path.join(path, '%s.%s' % (name, ext))
+                if os.path.exists(filepath):
+                    filename = filepath
+                    break
+
+        if filename is None:
             raise ProfileNotFound(name, profile_path)
 
     with open(filename) as fct:
@@ -76,7 +85,7 @@ def _load_profile(name, profile_path, inherits_set=None):
 
 
 def parse_profile(name, contents):
-    if name.endswith('.yaml'):
+    if _is_valid_extension(name):
         # this was a full path
         name = os.path.splitext(os.path.basename(name))[0]
     data = yaml.safe_load(contents)


### PR DESCRIPTION
Previously doc-warnings and test-warnings and similar were inherited even if a user provided their own profile, meaning there were some aspects that could not be changed by the profile.

Note that a separate pull request will improve the ability to restore the default behaviour of no test warnings by default and so on.