### PR TITLE
Complete rewrite of how profiles are parsed and combined

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -3,6 +3,7 @@ output-format: grouped
 strictness: veryhigh
 doc-warnings: true
 test-warnings: false
+max-line-length: 120
 
 ignore:
   - ^docs/
@@ -17,12 +18,18 @@ pylint:
   disable:
     - W0141
     - R0903
-  options:
-    max-line-length: 120
+    - C0111
 
 pep8:
-  full: true
   disable:
     - E126
-  options:
-    max-line-length: 120
+
+pep257:
+  disable:
+    - D100
+    - D101
+    - D102
+    - D103
+    - D205
+    - D400
+    - D401

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -21,6 +21,7 @@ pylint:
     - C0111
 
 pep8:
+  full: true
   disable:
     - E126
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Prospector Changelog
 =======
 
 ## Version 0.9
-* Profiles can now use options like 'strictness: high' or 'doc-warnings: true' as a shortcut for inheriting the built-in prospector profiles.
+* The way that profiles are handled and parsed has completely been rewritten to avoid several bugs and introduce 'shorthand' options to profiles. This allows profiles to specify simple options like 'doc-warnings: true' inside profiles and configure anything that can be configured as a command line argument. Profiles can now use options like 'strictness: high' or 'doc-warnings: true' as a shortcut for inheriting the built-in prospector profiles.
+* [#89](https://github.com/landscapeio/prospector/issues/89) and [#40](https://github.com/landscapeio/prospector/pull/40) - profile merging was not behaving exactly as intended, with later profiles not overriding earlier profiles. This is now fixed as part of the aforementioned rewrite.
 * pep257 is now included by default; however it will not run unless the '--doc-warnings' flag is used.
 * pep257 messages are now properly blended with other tools' documentation warnings
 

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -90,7 +90,9 @@ If creating your own profile, you can use the ``strictness`` like so:
 
     strictness: medium
 
-Valid values are 'verylow', 'low', 'medium' (the default), 'high' and 'veryhigh'.
+Valid values are 'verylow', 'low', 'medium' (the default), 'high' and 'veryhigh'. If you don't specify a
+strictness value, then the default of 'medium' will be used. To avoid using any of Prospector's default
+strictness profiles, set ``strictness: none``.
 
 
 Tweaking Certain Aspects

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -14,8 +14,12 @@ You can also use a name instead of the path, if it is on the ``profile-path``::
 
     prospector --profile my_profile
 
+In general, command-line arguments override and take precedence over values found
+in profiles.
+
 
 .. _profile_path:
+
 
 Profile Path
 ------------
@@ -140,6 +144,28 @@ on all warnings from pep8 but turn off just one or two individually or otherwise
             - E126
         options:
             max-line-length: 120
+
+
+Libraries Used and Autodetect
+.............................
+
+Prospector will adjust the behaviour of the underlying tools based on the libraries that your project
+uses. If you use Django, for example, the `pylint-django <https://github.com/landscapeio/pylint-django>` plugin
+will be loaded. This will happen automatically.
+
+If prospector is not correctly determining which of its supported libraries you use, you can specify
+it manually in the profile:
+
+    uses:
+        - django
+        - celery
+
+Currently, only Django and Celery have plugins.
+
+If prospector is incorrectly deciding that you use one of these, you can turn off autodetection:
+
+    autodetect: false
+
 
 
 Inheritance

--- a/docs/supported_tools.rst
+++ b/docs/supported_tools.rst
@@ -1,7 +1,7 @@
 Supported Tools
 ===============
 
-Prospector currently supports 8 tools, of which 5 are defaults and 4 are optional extras.
+Prospector currently supports 8 tools, of which 6 are defaults and 3 are optional extras.
 
 Enabling or Disabling Tools
 ---------------------------
@@ -78,16 +78,34 @@ Dodgy is a very simple tool designed to find 'dodgy' things which should
 not be in a public project, such as secret keys, passwords, AWS tokens or 
 source control diffs.
 
+`pep257 <https://github.com/GreenSteam/pep257>`_
+````````````````````````````````````````````````
+
+``pep257`` is a simple tool to warn about violations of the
+`PEP257 Docstring Conventions <http://legacy.python.org/dev/peps/pep-0257/>`_.
+It produces messages for any divergence from the style guide.
+
+This tool is currently considered *experimental* due to some bugs in its
+ability to parse code. For example, modules that contain an ``__all__`` could
+end up producing bogus error messages if the ``__all__`` isn't formatted
+exactly as ``pep257`` expects it.
+
+It will not run by default, and must be enabled explicitly (via ``--with-tool pep257``
+or in a :doc:`profile <profiles>`) or implicitly (using the ``--doc-warnings`` flag).
+
+
 
 Optional Extras
 ---------------
 
-These extras are integrated into prospector but are not activated by default. This is because their output is not necessarily useful for all projects.
+These extras are integrated into prospector but are not activated by default.
+This is because their output is not necessarily useful for all projects.
 
 They are also not installed by default. The instructions for installing each tool is in the tool 
 section below. To install all extras at the same time, install prospector using the ``with_everything`` option::
 
     pip install prospector[with_everything]
+
 
 `Pyroma <https://bitbucket.org/regebro/pyroma>`_
 ````````````````````````````````````````````````
@@ -127,22 +145,3 @@ To install and use::
 
     pip install prospector[with_frosted]
     prospector --with-tool frosted
-
-
-`pep257 <https://github.com/GreenSteam/pep257>`_
-````````````````````````````````````````````````
-
-``pep257`` is a simple tool to warn about violations of the
-`PEP257 Docstring Conventions <http://legacy.python.org/dev/peps/pep-0257/>`_.
-It produces messages for any divergence from the style guide.
-
-To install and use::
-
-    pip install prospector[with_pep257]
-    prospector --with-tool pep257
-
-This tool is currently considered *experimental* due to some bugs in its
-ability to parse code. For example, modules that contain an ``__all__`` could
-end up producing bogus error messages if the ``__all__`` isn't formatted
-exactly as ``pep257`` expects it.
-

--- a/prospector/finder.py
+++ b/prospector/finder.py
@@ -2,12 +2,14 @@ import os
 
 
 class SingleFiles(object):
+
     """
     When prospector is run in 'single file mode' - that is,
     the argument is a python module rather than a directory -
     then we'll use this object instead of the FoundFiles to
     give all the functionality needed to check a single file.
     """
+
     # The 'even if ignored' parameters are kept to show this is meant
     # to be API compatible with FoundFiles, but pylint will warn, so
     # let's disable

--- a/prospector/formatters/pylint.py
+++ b/prospector/formatters/pylint.py
@@ -4,6 +4,7 @@ from prospector.formatters.base import Formatter
 
 
 class PylintFormatter(Formatter):
+
     """
     This formatter outputs messages in the same way as pylint -f parseable , which is used by several
     tools to parse pylint output. This formatter is therefore a compatability shim between tools built

--- a/prospector/formatters/text.py
+++ b/prospector/formatters/text.py
@@ -15,11 +15,12 @@ class TextFormatter(Formatter):
         ('completed', 'Finished'),
         ('time_taken', 'Time Taken', lambda x: '%s seconds' % x),
         ('formatter', 'Formatter'),
+        ('profiles', 'Profiles'),
         ('strictness', 'Strictness'),
         ('libraries', 'Libraries Used', lambda x: ', '.join(x)),
         ('tools', 'Tools Run', lambda x: ', '.join(x)),
         ('adaptors', 'Adaptors', lambda x: ', '.join(x)),
-        ('message_count', 'Message Found'),
+        ('message_count', 'Messages Found'),
     )
 
     def render_summary(self):
@@ -39,7 +40,7 @@ class TextFormatter(Formatter):
                 else:
                     value = self.summary[key]
                 output.append(
-                    '%s: %s' % (
+                    ' %s: %s' % (
                         label.rjust(label_width),
                         value,
                     )

--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -1,6 +1,7 @@
+from prospector.tools import TOOLS
+
 import os
 import yaml
-from prospector.tools import TOOLS
 
 
 class ProfileNotFound(Exception):
@@ -13,31 +14,49 @@ class ProfileNotFound(Exception):
         return "Could not find profile %s; searched in %s" % (self.name, ':'.join(self.filepath))
 
 
-_EMPTY_DATA = {
-    'inherits': [],
-    'ignore': [],
-    'output-format': None
-}
+class ProspectorProfile(object):
 
+    def __init__(self, name, profile_dict, inherit_order):
+        self.name = name
+        self.inherit_order = inherit_order
+        self.ignore = profile_dict.get('ignore', [])
+        self.output_format = profile_dict.get('output-format')
+        self.autodetect = profile_dict.get('autodetect')
+        self.uses = _ensure_list(profile_dict.get('uses', []))
+        self.max_line_length = profile_dict.get('max-line-length')
 
-for toolname in TOOLS.keys():
-    _EMPTY_DATA[toolname] = {
-        'disable': [],
-        'enable': [],
-        'run': None,
-        'options': {}
-    }
+        for tool in TOOLS.keys():
+            conf = {
+                'disable': [],
+                'enable': [],
+                'run': None,
+                'options': {}
+            }
+            conf.update(profile_dict.get(tool, {}))
 
+            if self.max_line_length is not None and tool in ('pylint', 'pep8'):
+                conf['options']['max-line-length'] = self.max_line_length
 
-def _uniq_list(listval):
-    seen = set()
-    out = []
-    for value in listval:
-        if value in seen:
-            continue
-        out.append(value)
-        seen.add(value)
-    return out
+            setattr(self, tool, conf)
+
+    def get_disabled_messages(self, tool_name):
+        disable = getattr(self, tool_name)['disable']
+        enable = getattr(self, tool_name)['enable']
+        return list(set(disable) - set(enable))
+
+    def is_tool_enabled(self, name):
+        return getattr(self, name).get('run')
+
+    def list_profiles(self):
+        # this profile is itself included
+        return self.inherit_order
+
+    @staticmethod
+    def load(name_or_path, profile_path, allow_shorthand=True, forced_inherits=None):
+        # First simply load all of the profiles and those that it explicitly inherits from
+        data, inherits = _load_and_merge(name_or_path, profile_path, allow_shorthand,
+                                         forced_inherits=forced_inherits or [])
+        return ProspectorProfile(name_or_path, data, inherits)
 
 
 def _is_valid_extension(filename):
@@ -45,172 +64,211 @@ def _is_valid_extension(filename):
     return ext in ('.yml', '.yaml')
 
 
-def load_profiles(names, profile_path):
-    if not isinstance(names, (list, tuple)):
-        names = (names,)
-    profiles = [_load_profile(name, profile_path)[0] for name in names]
-    return merge_profiles(profiles)
-
-
-def _load_content(name, profile_path):
-    if _is_valid_extension(name):
+def _load_content(name_or_path, profile_path):
+    if _is_valid_extension(name_or_path) and os.path.exists(name_or_path):
         # assume that this is a full path that we can load
-        filename = name
+        filename = name_or_path
     else:
         filename = None
         for path in profile_path:
             for ext in ('yml', 'yaml'):
-                filepath = os.path.join(path, '%s.%s' % (name, ext))
+                filepath = os.path.join(path, '%s.%s' % (name_or_path, ext))
                 if os.path.exists(filepath):
                     filename = filepath
                     break
 
         if filename is None:
-            raise ProfileNotFound(name, profile_path)
+            raise ProfileNotFound(name_or_path, profile_path)
 
     with open(filename) as fct:
-        return fct.read()
+        return yaml.safe_load(fct) or {}
 
 
-def from_file(name, profile_path):
-    return parse_profile(name, _load_content(name, profile_path))
+def _ensure_list(value):
+    if isinstance(value, list):
+        return value
+    return [value]
 
 
-def _load_profile(name, profile_path, inherits_set=None):
-    inherits_set = inherits_set or set()
-
-    profile = parse_profile(name, _load_content(name, profile_path))
-    inherits_set.add(profile.name)
-
-    for inherited in profile.inherits:
-        if inherited not in inherits_set:
-            inherited_profile, sub_inherits_set = _load_profile(
-                inherited,
-                profile_path,
-                inherits_set,
-            )
-            profile.merge(inherited_profile)
-            inherits_set |= sub_inherits_set
-
-    return profile, inherits_set
+def _simple_merge_dict(priority, base):
+    out = dict(base.items())
+    out.update(dict(priority.items()))
+    return out
 
 
-def parse_profile(name, contents):
-    data = yaml.safe_load(contents)
-    if data is None:
-        # this happens if a completely empty YAML file is passed in to
-        # parse_profile, for example
-        data = dict(_EMPTY_DATA)
-    else:
-        data = _merge_dict(_EMPTY_DATA, data, dict1_priority=False)
-    return ProspectorProfile(name, data)
+def _merge_tool_config(priority, base):
+    out = dict(base.items())
+    for key, value in priority.items():
+        if key in ('run', 'full', 'none'):  # pep8 has extra 'full' and 'none' options
+            out[key] = value
+        elif key in ('options',):
+            out[key] = _simple_merge_dict(value, base.get(key, {}))
+
+    # anything enabled in the 'priority' dict is removed
+    # from 'disabled' in the base dict and vice versa
+    base_disabled = base.get('disable') or []
+    base_enabled = base.get('enable') or []
+    pri_disabled = priority.get('disable') or []
+    pri_enabled = priority.get('enable') or []
+
+    out['disable'] = list(set(pri_disabled) | (set(base_disabled) - set(pri_enabled)))
+    out['enable'] = list(set(pri_enabled) | (set(base_enabled) - set(pri_disabled)))
+
+    return out
 
 
-def _merge_dict(dict1, dict2, dedup_lists=False, dict1_priority=True):
-    newdict = {}
-    newdict.update(dict1)
+def _merge_profile_dict(priority, base):
+    # copy the base dict into our output
+    out = dict(base.items())
 
-    for key, value in dict2.items():
-        if key not in dict1:
-            newdict[key] = value
-        elif value is None and dict1[key] is not None:
-            newdict[key] = dict1[key]
-        elif dict1[key] is None and value is not None:
-            newdict[key] = value
-        elif type(value) != type(dict1[key]):
-            raise ValueError("Could not merge conflicting types %s and %s" % (
-                type(value),
-                type(dict1[key]),
-            ))
-        elif isinstance(value, dict):
-            newdict[key] = _merge_dict(
-                dict1[key],
-                value,
-                dedup_lists,
-                dict1_priority,
-            )
-        elif isinstance(value, (list, tuple)):
-            newdict[key] = list(set(dict1[key]) | set(value))
-        elif not dict1_priority:
-            newdict[key] = value
+    for key, value in priority.items():
+        if key in ('strictness', 'doc-warnings', 'test-warnings', 'output-format', 'autodetect', 'max-line-length'):
+            # some keys are simple values which are overwritten
+            out[key] = value
+        elif key in ('ignore', 'uses'):
+            # some keys should be appended
+            out[key] = _ensure_list(value) + _ensure_list(base.get(key, []))
+        elif key in TOOLS.keys():
+            # this is tool config!
+            out[key] = _merge_tool_config(value, base.get(key, {}))
 
-    return newdict
+    return out
 
 
-class ProspectorProfile(object):
+def _determine_strictness(profile_dict, inherits):
+    for profile in inherits:
+        if profile.startswith('strictness_'):
+            return None, False
 
-    def __init__(self, name, profile_dict):
-        self.name = name
-        self.inherits = profile_dict['inherits']
-        self.ignore = profile_dict['ignore']
-        self.output_format = profile_dict['output-format']
-
-        # some profile options are shorthand for inheriting
-        # from built-in prospector profiles
-        if _is_valid_extension(name):
-            # with an extension, this is a prospector profile
-            # rather than a user-provided one
-            self._determine_strictness(profile_dict)
-            self._determine_pep8(profile_dict)
-            self._determine_doc_warnings(profile_dict)
-            self._determine_test_warnings(profile_dict)
-
-        for tool in TOOLS.keys():
-            setattr(self, tool, profile_dict[tool])
-
-    def _determine_strictness(self, profile_dict):
-        for profile in self.inherits:
-            if profile.startswith('strictness_'):
-                return
-
-        strictness = profile_dict.get('strictness', 'medium')
-        self.inherits.append('strictness_%s' % strictness)
-
-    def _determine_pep8(self, profile_dict):
-        pep8 = profile_dict.get('pep8', {})
-        if pep8.get('full', False):
-            self.inherits.append('full_pep8')
-        elif pep8.get('none', False):
-            self.inherits.append('no_pep8')
-
-    def _determine_doc_warnings(self, profile_dict):
-        if not profile_dict.get('doc-warnings', False):
-            self.inherits.append('no_doc_warnings')
-
-    def _determine_test_warnings(self, profile_dict):
-        if not profile_dict.get('test-warnings', False):
-            self.inherits.append('no_test_warnings')
-
-    def to_profile_dict(self):
-        thedict = {
-            'inherits': self.inherits,
-            'ignore': self.ignore,
-        }
-
-        for tool in TOOLS.keys():
-            thedict[tool] = getattr(self, tool)
-
-    def get_disabled_messages(self, tool_name):
-        disable = getattr(self, tool_name)['disable']
-        enable = getattr(self, tool_name)['enable']
-        return list(set(disable) - set(enable))
-
-    def merge(self, other_profile):
-        self.ignore = _uniq_list(self.ignore + other_profile.ignore)
-        self.inherits = _uniq_list(self.inherits + other_profile.inherits)
-        if other_profile.output_format is not None:
-            self.output_format = other_profile.output_format
-
-        for tool in TOOLS.keys():
-            merged = _merge_dict(getattr(self, tool), getattr(other_profile, tool))
-            setattr(self, tool, merged)
-
-    def is_tool_enabled(self, name):
-        return getattr(self, name)['run']
+    strictness = profile_dict.get('strictness')
+    if strictness is None:
+        return None, False
+    return ('strictness_%s' % strictness), True
 
 
-def merge_profiles(profiles):
-    merged_profile = profiles[0]
-    for profile in profiles[1:]:
-        merged_profile.merge(profile)
-    return merged_profile
+def _determine_pep8(profile_dict):
+    pep8 = profile_dict.get('pep8', {})
+    if pep8.get('full', False):
+        return 'full_pep8', True
+    elif pep8.get('none', False):
+        return 'no_pep8', True
+    return None, False
+
+
+def _determine_doc_warnings(profile_dict):
+    doc_warnings = profile_dict.get('doc-warnings')
+    if doc_warnings is None:
+        return None, False
+    return ('doc_warnings' if doc_warnings else 'no_doc_warnings'), True
+
+
+def _determine_test_warnings(profile_dict):
+    test_warnings = profile_dict.get('test-warnings')
+    if test_warnings is None:
+        return None, False
+    return (None if test_warnings else 'no_test_warnings'), True
+
+
+def _determine_implicit_inherits(profile_dict, already_inherits, shorthands_found):
+    # Note: the ordering is very important here - the earlier items
+    # in the list have precedence over the later items. The point of
+    # the doc/test/pep8 profiles is usually to restore items which were
+    # turned off in the strictness profile, so they must appear first.
+    implicit = [
+        ('pep8', _determine_pep8(profile_dict)),
+        ('docs', _determine_doc_warnings(profile_dict)),
+        ('tests', _determine_test_warnings(profile_dict)),
+        ('strictness', _determine_strictness(profile_dict, already_inherits))
+    ]
+    inherits = []
+
+    for shorthand_name, determined in implicit:
+        if shorthand_name in shorthands_found:
+            continue
+        extra_inherits, shorthand_found = determined
+        if not shorthand_found:
+            continue
+        shorthands_found.add(shorthand_name)
+        if extra_inherits is not None:
+            inherits.append(extra_inherits)
+
+    return inherits, shorthands_found
+
+
+def _append_profiles(name, profile_path, data, inherit_list, allow_shorthand=False):
+    new_data, new_il, _ = _load_profile(name, profile_path, allow_shorthand=allow_shorthand)
+    data.update(new_data)
+    inherit_list += new_il
+    return data, inherit_list
+
+
+def _load_and_merge(name_or_path, profile_path, allow_shorthand=True, forced_inherits=None):
+    # First simply load all of the profiles and those that it explicitly inherits from
+    data, inherit_list, shorthands_found = _load_profile(name_or_path, profile_path,
+                                                         allow_shorthand=allow_shorthand,
+                                                         forced_inherits=forced_inherits or [])
+
+    if allow_shorthand:
+        if 'docs' not in shorthands_found:
+            data, inherit_list = _append_profiles('no_doc_warnings', profile_path, data, inherit_list)
+
+        if 'tests' not in shorthands_found:
+            data, inherit_list = _append_profiles('no_test_warnings', profile_path, data, inherit_list)
+
+        if 'strictness' not in shorthands_found:
+            # if no strictness was specified, then we should manually insert the medium strictness
+            for inherit in inherit_list:
+                if inherit.startswith('strictness_'):
+                    break
+            else:
+                data, inherit_list = _append_profiles('strictness_medium', profile_path, data, inherit_list)
+
+    # Now we merge all of the values together, from 'right to left' (ie, from the
+    # top of the inheritance tree to the bottom). This means that the lower down
+    # values overwrite those from above, meaning that the initially provided profile
+    # has precedence.
+    merged = {}
+    for name in inherit_list[::-1]:
+        priority = data[name]
+        merged = _merge_profile_dict(priority, merged)
+
+    return merged, inherit_list
+
+
+def _load_profile(name_or_path, profile_path, shorthands_found=None,
+                  already_loaded=None, allow_shorthand=True, forced_inherits=None):
+    # recursively get the contents of the basic profile and those it inherits from
+    base_contents = _load_content(name_or_path, profile_path)
+
+    inherit_order = [name_or_path]
+    shorthands_found = shorthands_found or set()
+
+    already_loaded = already_loaded or []
+    already_loaded.append(name_or_path)
+
+    inherits = _ensure_list(base_contents.get('inherits', []))
+    if forced_inherits is not None:
+        inherits += forced_inherits
+
+    # There are some 'shorthand' options in profiles which implicitly mean that we
+    # should inherit from some of prospector's built-in profiles
+    if base_contents.get('allow-shorthand', True) and allow_shorthand:
+        extra_inherits, extra_shorthands = _determine_implicit_inherits(base_contents, inherits, shorthands_found)
+        inherits += extra_inherits
+        shorthands_found |= extra_shorthands
+
+    contents_dict = {name_or_path: base_contents}
+
+    for inherit_profile in inherits:
+        if inherit_profile in already_loaded:
+            # we already have this loaded and in the list
+            continue
+
+        already_loaded.append(inherit_profile)
+        new_cd, new_il, new_sh = _load_profile(inherit_profile, profile_path,
+                                               shorthands_found, already_loaded, allow_shorthand)
+        contents_dict.update(new_cd)
+        inherit_order += new_il
+        shorthands_found |= new_sh
+
+    return contents_dict, inherit_order, shorthands_found

--- a/prospector/profiles/profiles/default.yaml
+++ b/prospector/profiles/profiles/default.yaml
@@ -1,0 +1,11 @@
+strictness: medium
+doc-warnings: true
+test-warnings: false
+autodetect: true
+
+pep8:
+  full: true
+  options:
+    max-line-length: 999999999999999999
+  disable:
+   - E201

--- a/prospector/profiles/profiles/doc_warnings.yaml
+++ b/prospector/profiles/profiles/doc_warnings.yaml
@@ -1,0 +1,4 @@
+allow-shorthand: false
+
+pep257:
+  run: true

--- a/prospector/profiles/profiles/full_pep8.yaml
+++ b/prospector/profiles/profiles/full_pep8.yaml
@@ -1,3 +1,4 @@
+allow-shorthand: false
 
 pep8:
   run: true

--- a/prospector/profiles/profiles/no_doc_warnings.yaml
+++ b/prospector/profiles/profiles/no_doc_warnings.yaml
@@ -1,3 +1,5 @@
+allow-shorthand: false
+
 ignore:
   - ^docs?/
 

--- a/prospector/profiles/profiles/no_pep8.yaml
+++ b/prospector/profiles/profiles/no_pep8.yaml
@@ -1,3 +1,4 @@
+allow-shorthand: false
 
 pylint:
   disable:

--- a/prospector/profiles/profiles/no_test_warnings.yaml
+++ b/prospector/profiles/profiles/no_test_warnings.yaml
@@ -1,3 +1,5 @@
+allow-shorthand: false
+
 ignore:
   - ^tests?/?
   - /tests?(/|$)

--- a/prospector/profiles/profiles/strictness_high.yaml
+++ b/prospector/profiles/profiles/strictness_high.yaml
@@ -1,3 +1,5 @@
+allow-shorthand: false
+
 inherits:
   - strictness_veryhigh
 

--- a/prospector/profiles/profiles/strictness_low.yaml
+++ b/prospector/profiles/profiles/strictness_low.yaml
@@ -1,3 +1,5 @@
+allow-shorthand: false
+
 inherits:
   - strictness_medium
   

--- a/prospector/profiles/profiles/strictness_medium.yaml
+++ b/prospector/profiles/profiles/strictness_medium.yaml
@@ -1,3 +1,5 @@
+allow-shorthand: false
+
 inherits:
   - strictness_high
 

--- a/prospector/profiles/profiles/strictness_none.yaml
+++ b/prospector/profiles/profiles/strictness_none.yaml
@@ -1,0 +1,3 @@
+# Dummy profile used for 'strictness: none', which is necessary to
+# prevent a default of medium if no strictness is specified.
+allow-shorthand: false

--- a/prospector/profiles/profiles/strictness_veryhigh.yaml
+++ b/prospector/profiles/profiles/strictness_veryhigh.yaml
@@ -1,4 +1,5 @@
 # This will enable almost every single warning
+allow-shorthand: false
 
 ignore:
   - (^|/)\..+

--- a/prospector/profiles/profiles/strictness_verylow.yaml
+++ b/prospector/profiles/profiles/strictness_verylow.yaml
@@ -1,3 +1,5 @@
+allow-shorthand: false
+
 inherits:
   - strictness_low
 

--- a/prospector/tools/base.py
+++ b/prospector/tools/base.py
@@ -1,6 +1,10 @@
 
 
 class ToolBase(object):
+    # This is an 'abstract' base class, used to provide an indication of
+    # how to create a new tool class. Therefore, the arguments will be unused,
+    # so that is suppressed here.
+    # pylint: disable=W0613
 
     def configure(self, prospector_config, found_files):
         """

--- a/prospector/tools/pep257/__init__.py
+++ b/prospector/tools/pep257/__init__.py
@@ -31,7 +31,7 @@ class Pep257Tool(ToolBase):
                 for error in checker.check_source(
                         open(code_file, 'r').read(),
                         code_file,
-                        ):
+                ):
                     location = Location(
                         path=code_file,
                         module=None,

--- a/prospector/tools/pep8/__init__.py
+++ b/prospector/tools/pep8/__init__.py
@@ -126,7 +126,7 @@ class Pep8Tool(ToolBase):
             # adding prospector-flavoured configuration.
             # pylint: disable=W0201
             self.checker.select = ()
-            self.checker.ignore = prospector_config.get_disabled_messages('pep8')
+            self.checker.options.ignore = tuple(prospector_config.get_disabled_messages('pep8'))
 
             if 'max-line-length' in prospector_config.tool_options('pep8'):
                 self.checker.options.max_line_length = \

--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -28,7 +28,9 @@ class DummyStream(object):
         pass
 
 
-class stdout_wrapper(object):  # noqa
+# The class name here is lowercase as it is a context manager, which
+# typically tend to me lowercase.
+class stdout_wrapper(object):  # noqa pylint:disable=C0103
 
     def __init__(self, hide_stdout):
         self.hide_stdout = hide_stdout
@@ -57,6 +59,7 @@ class PylintTool(ToolBase):
         self._collector = self._linter = None
         self._orig_sys_path = []
         self._streams = []
+        self._hide_stdout = False
 
     def _prospector_configure(self, prospector_config, linter):
         linter.load_default_plugins()
@@ -142,7 +145,7 @@ class PylintTool(ToolBase):
         for filepath in found_files.iter_module_paths(abspath=False):
             package = os.path.dirname(filepath).split(os.path.sep)
             for i in range(0, len(package)):
-                if os.path.join(*package[:i+1]) in check_paths:
+                if os.path.join(*package[:i + 1]) in check_paths:
                     break
             else:
                 check_paths.add(filepath)
@@ -209,8 +212,8 @@ class PylintTool(ToolBase):
 
     def _combine_w0614(self, messages):
         """
-        For the "unused import from wildcard import" messages, we want to combine all warnings about
-        the same line into a single message
+        For the "unused import from wildcard import" messages,
+        we want to combine all warnings about the same line into a single message.
         """
         by_loc = defaultdict(list)
         out = []
@@ -234,8 +237,9 @@ class PylintTool(ToolBase):
 
     def combine(self, messages):
         """
-        Some error messages are repeated, causing many errors where only one is strictly necessary. For
-        example, having a wildcard import will result in one 'Unused Import' warning for every unused import.
+        Some error messages are repeated, causing many errors where only one is strictly necessary.
+
+        For example, having a wildcard import will result in one 'Unused Import' warning for every unused import.
         This method will combine these into a single warning.
         """
         combined = self._combine_w0614(messages)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ _INSTALL_REQUIRES = [
 _PACKAGE_DATA = {
     'prospector': [
         'blender_combinations.yaml',
+        'profiles/profiles/default.yaml',
+        'profiles/profiles/doc_warnings.yaml',
         'profiles/profiles/full_pep8.yaml',
         'profiles/profiles/no_doc_warnings.yaml',
         'profiles/profiles/no_pep8.yaml',
@@ -41,6 +43,7 @@ _PACKAGE_DATA = {
         'profiles/profiles/strictness_high.yaml',
         'profiles/profiles/strictness_low.yaml',
         'profiles/profiles/strictness_medium.yaml',
+        'profiles/profiles/strictness_none.yaml',
         'profiles/profiles/strictness_veryhigh.yaml',
         'profiles/profiles/strictness_verylow.yaml',
     ]

--- a/tests/profiles/profiles/inheritance/pep8/base.yaml
+++ b/tests/profiles/profiles/inheritance/pep8/base.yaml
@@ -1,0 +1,2 @@
+pep8:
+  none: true

--- a/tests/profiles/profiles/inheritance/pep8/start.yaml
+++ b/tests/profiles/profiles/inheritance/pep8/start.yaml
@@ -1,0 +1,5 @@
+inherits:
+  - base
+
+pep8:
+  full: true

--- a/tests/profiles/profiles/inheritance/precedence/base1.yaml
+++ b/tests/profiles/profiles/inheritance/precedence/base1.yaml
@@ -1,4 +1,3 @@
-strictness: none
 
 pylint:
   run: false

--- a/tests/profiles/profiles/inheritance/precedence/base2.yaml
+++ b/tests/profiles/profiles/inheritance/precedence/base2.yaml
@@ -1,0 +1,8 @@
+inherits:
+  - base1
+
+pylint:
+  run: true
+  disable:
+    - C0111
+    - W0106

--- a/tests/profiles/profiles/inheritance/precedence/start.yaml
+++ b/tests/profiles/profiles/inheritance/precedence/start.yaml
@@ -1,0 +1,9 @@
+strictness: none
+
+inherits:
+  - base2
+
+pylint:
+  run: true
+  enable:
+    - C0111

--- a/tests/profiles/profiles/inheritance/shorthand_inheritance/base1.yaml
+++ b/tests/profiles/profiles/inheritance/shorthand_inheritance/base1.yaml
@@ -1,0 +1,3 @@
+strictness: medium
+doc-warnings: true
+test-warnings: false

--- a/tests/profiles/profiles/inheritance/shorthand_inheritance/base2.yaml
+++ b/tests/profiles/profiles/inheritance/shorthand_inheritance/base2.yaml
@@ -1,0 +1,5 @@
+inherits:
+ - base1
+
+test-warnings: true
+doc-warnings: false

--- a/tests/profiles/profiles/inheritance/shorthand_inheritance/start.yaml
+++ b/tests/profiles/profiles/inheritance/shorthand_inheritance/start.yaml
@@ -1,0 +1,5 @@
+inherits:
+ - base2
+
+strictness: high
+doc-warnings: true

--- a/tests/profiles/profiles/inheritance/strictness_equivalence/start.yaml
+++ b/tests/profiles/profiles/inheritance/strictness_equivalence/start.yaml
@@ -1,0 +1,5 @@
+# this should be basically equivalent to the strictness_medium profile
+strictness: medium
+doc-warnings: false
+test-warmings: false
+

--- a/tests/profiles/profiles/mergetest1.yaml
+++ b/tests/profiles/profiles/mergetest1.yaml
@@ -1,5 +1,0 @@
-
-pylint:
-  disable:
-    - C1000
-    - C1001

--- a/tests/profiles/profiles/mergetest2.yaml
+++ b/tests/profiles/profiles/mergetest2.yaml
@@ -1,6 +1,0 @@
-
-pylint:
-  disable:
-    - W1010
-    - W1012
-    - C1000

--- a/tests/profiles/profiles/mergetest3.yaml
+++ b/tests/profiles/profiles/mergetest3.yaml
@@ -1,5 +1,0 @@
-
-pylint:
-  disable:
-    - E0504
-    - W1010

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -81,7 +81,7 @@ class TestProfileInheritance(ProfileTestBase):
                                                  # don't implicitly add things
                                                  allow_shorthand=False,
                                                  # but do include the profiles that the start.yaml will
-                                                 forced_inherits=['doc_warnings', 'test_warnings']
+                                                 forced_inherits=['doc_warnings']
         )
         self.assertDictEqual(profile.pylint, high_strictness.pylint)
         self.assertDictEqual(profile.pep8, high_strictness.pep8)

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -1,24 +1,30 @@
 import os
 from unittest import TestCase
-from prospector.profiles.profile import _merge_dict, merge_profiles, from_file, load_profiles
+from prospector.profiles.profile import ProspectorProfile
 
 
-class TestProfileParsing(TestCase):
+class ProfileTestBase(TestCase):
 
     def setUp(self):
-        self._profile_path = [os.path.join(os.path.dirname(__file__), 'profiles')]
+        self._profile_path = [
+            os.path.join(os.path.dirname(__file__), 'profiles'),
+            os.path.join(os.path.dirname(__file__), '../../prospector/profiles/profiles')
+        ]
 
     def _file_content(self, name):
         path = os.path.join(self._profile_path, name)
         with open(path) as f:
             return f.read()
 
+
+class TestProfileParsing(ProfileTestBase):
+
     def test_empty_disable_list(self):
         """
         This test verifies that a profile can still be loaded if it contains
         an empty 'pylint.disable' list
         """
-        profile = load_profiles('empty_disable_list', self._profile_path)
+        profile = ProspectorProfile.load('empty_disable_list', self._profile_path, allow_shorthand=False)
         self.assertEqual([], profile.pylint['disable'])
 
     def test_empty_profile(self):
@@ -26,85 +32,61 @@ class TestProfileParsing(TestCase):
         Verifies that a completely empty profile can still be parsed and have
         default values
         """
-        profile = load_profiles('empty_profile', self._profile_path)
+        profile = ProspectorProfile.load('empty_profile', self._profile_path, allow_shorthand=False)
         self.assertEqual([], profile.pylint['disable'])
 
-    def test_inheritance(self):
-        profile = load_profiles('inherittest3', self._profile_path)
+    def test_ignores(self):
+        profile = ProspectorProfile.load('ignores', self._profile_path)
+        self.assertEqual(['^tests/', '/migrations/'].sort(), profile.ignore.sort())
+
+    def test_disable_tool(self):
+        profile = ProspectorProfile.load('pylint_disabled', self._profile_path)
+        self.assertFalse(profile.is_tool_enabled('pylint'))
+        self.assertTrue(profile.is_tool_enabled('pep8') is None)
+
+
+class TestProfileInheritance(ProfileTestBase):
+
+    def _example_path(self, testname):
+        return os.path.join(os.path.dirname(__file__), 'profiles', 'inheritance', testname)
+
+    def _load(self, testname):
+        profile_path = self._profile_path + [self._example_path(testname)]
+        return ProspectorProfile.load('start', profile_path)
+
+    def test_simple_inheritance(self):
+        profile = ProspectorProfile.load('inherittest3', self._profile_path, allow_shorthand=False)
         disable = profile.pylint['disable']
         disable.sort()
         self.assertEqual(['I0001', 'I0002', 'I0003'], disable)
 
-    def test_profile_merge(self):
-
-        profile1 = from_file('mergetest1', self._profile_path)
-        profile2 = from_file('mergetest2', self._profile_path)
-        profile3 = from_file('mergetest3', self._profile_path)
-
-        merged = merge_profiles((profile1, profile2, profile3))
-
-        merged_disabled_warnings = merged.pylint['disable']
-        merged_disabled_warnings.sort()
-        expected = ['C1000', 'C1001', 'E0504', 'W1010', 'W1012']
-        self.assertEqual(expected, merged_disabled_warnings)
-
-    def test_ignores(self):
-        profile = load_profiles('ignores', self._profile_path)
-        self.assertEqual(['^tests/', '/migrations/'].sort(), profile.ignore.sort())
-
-    def test_disable_tool(self):
-        profile = load_profiles('pylint_disabled', self._profile_path)
-        self.assertFalse(profile.is_tool_enabled('pylint'))
-        self.assertTrue(profile.is_tool_enabled('pep8') is None)
-
     def test_disable_tool_inheritance(self):
-        profile = load_profiles('pep8_and_pylint_disabled', self._profile_path)
+        profile = ProspectorProfile.load('pep8_and_pylint_disabled', self._profile_path)
         self.assertFalse(profile.is_tool_enabled('pylint'))
         self.assertFalse(profile.is_tool_enabled('pep8'))
 
-    def test_dict_merge(self):
-        a = {
-            'int': 1,
-            'str': 'fish',
-            'bool': True,
-            'list': [1, 2],
-            'dict': {
-                'a': 1,
-                'b': 2
-            }
-        }
-        b = {
-            'int': 2,
-            'list': [2, 3],
-            'bool': False,
-            'dict': {
-                'a': 3,
-                'c': 4
-            }
-        }
+    def test_precedence(self):
+        profile = self._load('precedence')
+        self.assertTrue(profile.is_tool_enabled('pylint'))
+        self.assertTrue('W0106' in profile.get_disabled_messages('pylint'))
 
-        expected = {
-            'int': 2,
-            'str': 'fish',
-            'bool': False,
-            'list': [1, 2, 3],
-            'dict': {
-                'a': 3,
-                'b': 2,
-                'c': 4
-            }
-        }
-        self.assertEqual(expected, _merge_dict(a, b, dedup_lists=True, dict1_priority=False))
+    def test_strictness_equivalence(self):
+        profile = self._load('strictness_equivalence')
+        medium_strictness = ProspectorProfile.load('strictness_medium', self._profile_path)
+        self.assertListEqual(sorted(profile.pylint['disable']), sorted(medium_strictness.pylint['disable']))
 
-        expected = {
-            'int': 1,
-            'str': 'fish',
-            'bool': True,
-            'list': [1, 2, 3],
-            'dict': {
-                'a': 1,
-                'b': 2,
-                'c': 4
-            }
-        }
-        self.assertEqual(expected, _merge_dict(a, b, dedup_lists=True, dict1_priority=True))
+    def test_shorthand_inheritance(self):
+        profile = self._load('shorthand_inheritance')
+        high_strictness = ProspectorProfile.load('strictness_high', self._profile_path,
+                                                 # don't implicitly add things
+                                                 allow_shorthand=False,
+                                                 # but do include the profiles that the start.yaml will
+                                                 forced_inherits=['doc_warnings', 'test_warnings']
+        )
+        self.assertDictEqual(profile.pylint, high_strictness.pylint)
+        self.assertDictEqual(profile.pep8, high_strictness.pep8)
+        self.assertDictEqual(profile.pyflakes, high_strictness.pyflakes)
+
+    def test_pep8_inheritance(self):
+        profile = self._load('pep8')
+        self.assertTrue(profile.is_tool_enabled('pep8'))


### PR DESCRIPTION
This fixes problems with merging and introduces "shorthand" attributes, which are essentially user-friendly ways of inheriting the built-in prospector profiles - for example, the following is now possible:

```
strictness: high
doc-warnings: true
```

This will also fix #89 and #40 as well as help address https://github.com/landscapeio/landscape-issues/issues/83 and https://github.com/landscapeio/landscape-issues/issues/56