### PR TITLE
Rename pyflakes codes

### DIFF
--- a/prospector/profiles/profiles/no_doc_warnings.yaml
+++ b/prospector/profiles/profiles/no_doc_warnings.yaml
@@ -8,10 +8,6 @@ pylint:
     - empty-docstring
     - missing-docstring
 
-pyflakes:
-  disable:
-    - FL0007
-
 frosted:
   disable:
     - E401

--- a/prospector/profiles/profiles/strictness_low.yaml
+++ b/prospector/profiles/profiles/strictness_low.yaml
@@ -40,8 +40,8 @@ pylint:
 
 pyflakes:
   disable:
-    - FL0001
-    - FL0013
+    - F401
+    - F841
 
 frosted:
   disable:

--- a/prospector/profiles/profiles/strictness_medium.yaml
+++ b/prospector/profiles/profiles/strictness_medium.yaml
@@ -50,8 +50,8 @@ mccabe:
 
 pyflakes:
   disable:
-    - FL0005
-    - FL0011
+    - F403
+    - F810
 
 frosted:
   disable:

--- a/prospector/tools/profile_validator/__init__.py
+++ b/prospector/tools/profile_validator/__init__.py
@@ -4,6 +4,7 @@ import yaml
 from prospector.message import Location, Message
 from prospector.profiles import AUTO_LOADED_PROFILES
 from prospector.tools import ToolBase
+from prospector.tools import pyflakes
 
 
 CONFIG_SETTING_SHOULD_BE_LIST = 'should-be-list'
@@ -13,6 +14,7 @@ CONFIG_SETTING_MUST_BE_BOOL = 'should-be-bool'
 CONFIG_INVALID_VALUE = 'invalid-value'
 CONFIG_INVALID_REGEXP = 'invalid-regexp'
 CONFIG_DEPRECATED_SETTING = 'deprecated'
+CONFIG_DEPRECATED_CODE = 'deprecated-tool-code'
 
 
 class ProfileValidationTool(ToolBase):
@@ -103,6 +105,13 @@ class ProfileValidationTool(ToolBase):
         for key in parsed.keys():
             if key not in ProfileValidationTool.ALL_SETTINGS and key not in self.tool_names():
                 add_message(CONFIG_UNKNOWN_SETTING, '"%s" is not a valid prospector setting' % key, key)
+
+        if 'pyflakes' in parsed:
+            for code in parsed['pyflakes'].get('enable', []) + parsed['pyflakes'].get('disable', []):
+                if code in pyflakes.LEGACY_CODE_MAP:
+                    add_message(CONFIG_DEPRECATED_CODE,
+                                'Pyflakes code %s was renamed to %s' % (code, pyflakes.LEGACY_CODE_MAP[code]),
+                                'pyflakes')
 
         return messages
 

--- a/prospector/tools/pyflakes/__init__.py
+++ b/prospector/tools/pyflakes/__init__.py
@@ -12,20 +12,39 @@ __all__ = (
 )
 
 
+# Prospector uses the same pyflakes codes as flake8 defines,
+# see http://flake8.readthedocs.org/en/latest/warnings.html
+# and https://bitbucket.org/tarek/flake8/src/a209fb69350c572c9b2d7b4b09c7657be153be5e/flake8/_pyflakes.py
 _MESSAGE_CODES = {
-    'UnusedImport': 'FL0001',
-    'RedefinedWhileUnused': 'FL0002',
-    'RedefinedInListComp': 'FL0003',
-    'ImportShadowedByLoopVar': 'FL0004',
-    'ImportStarUsed': 'FL0005',
-    'UndefinedName': 'FL0006',
-    'DoctestSyntaxError': 'FL0007',
-    'UndefinedExport': 'FL0008',
-    'UndefinedLocal': 'FL0009',
-    'DuplicateArgument': 'FL0010',
-    'Redefined': 'FL0011',
-    'LateFutureImport': 'FL0012',
-    'UnusedVariable': 'FL0013',
+    'UnusedImport': 'F401',
+    'ImportShadowedByLoopVar': 'F402',
+    'ImportStarUsed': 'F403',
+    'LateFutureImport': 'F404',
+    'Redefined': 'F810',
+    'RedefinedWhileUnused': 'F811',
+    'RedefinedInListComp': 'F812',
+    'UndefinedName': 'F821',
+    'UndefinedExport': 'F822',
+    'UndefinedLocal': 'F823',
+    'DuplicateArgument': 'F831',
+    'UnusedVariable': 'F841',
+}
+
+# The old prospector codes were deprecated in favour of using the codes
+# defined by flake8. This maps the old codes to the new codes.
+LEGACY_CODE_MAP = {
+    'FL0001': 'F401',
+    'FL0002': 'F811',
+    'FL0003': 'F812',
+    'FL0004': 'F402',
+    'FL0005': 'F403',
+    'FL0006': 'F821',
+    'FL0008': 'F822',
+    'FL0009': 'F823',
+    'FL0010': 'F831',
+    'FL0011': 'F810',
+    'FL0012': 'F404',
+    'FL0013': 'F841',
 }
 
 
@@ -44,7 +63,7 @@ class ProspectorReporter(Reporter):
             code=None,
             message=None):
 
-        code = code or 'FL0000'
+        code = code or 'F999'
         if code in self.ignore:
             return
 
@@ -66,7 +85,7 @@ class ProspectorReporter(Reporter):
     def unexpectedError(self, filename, msg):  # noqa
         self.record_message(
             filename=filename,
-            code='FL9997',
+            code='F999',
             message=msg,
         )
 
@@ -76,12 +95,12 @@ class ProspectorReporter(Reporter):
             filename=filename,
             line=lineno,
             character=offset,
-            code='FL9998',
+            code='F999',
             message=msg,
         )
 
     def flake(self, message):
-        code = _MESSAGE_CODES.get(message.__class__.__name__, 'FL9999')
+        code = _MESSAGE_CODES.get(message.__class__.__name__, 'F999')
 
         self.record_message(
             filename=message.filename,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ _PACKAGES = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 _INSTALL_REQUIRES = [
     'pylint>=1.4',
     'pylint-celery>=0.3',
-    'pylint-django>=0.5.5',
+    'pylint-django>=0.6',
     'pylint-plugin-utils>=0.2.2',
     'pylint-common>=0.2.1',
     'requirements-detector>=0.3',


### PR DESCRIPTION
They should match those of flake8, because why not.

http://flake8.readthedocs.org/en/latest/warnings.html

The profile-validator will also produce a warning to indicate how to rename the codes.