### PR TITLE
Disabling warnings about members not existing by default

### DIFF
--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -105,19 +105,21 @@ class ProspectorConfig(object):
             profile_name = 'default'
             extra_profiles = []
 
-            if config.doc_warnings is not None and config.doc_warnings:
-                cmdline_implicit.append('doc_warnings')
-            if config.test_warnings is not None and config.test_warnings:
-                cmdline_implicit.append('test_warnings')
-            if config.no_style_warnings is not None and config.no_style_warnings:
-                cmdline_implicit.append('no_pep8')
-            if config.full_pep8 is not None and config.full_pep8:
-                cmdline_implicit.append('full_pep8')
+        if config.doc_warnings is not None and config.doc_warnings:
+            cmdline_implicit.append('doc_warnings')
+        if config.test_warnings is not None and config.test_warnings:
+            cmdline_implicit.append('test_warnings')
+        if config.no_style_warnings is not None and config.no_style_warnings:
+            cmdline_implicit.append('no_pep8')
+        if config.full_pep8 is not None and config.full_pep8:
+            cmdline_implicit.append('full_pep8')
+        if config.member_warnings is not None and config.member_warnings:
+            cmdline_implicit.append('member_warnings')
 
-            # Use the strictness profile only if no profile has been given
-            if config.strictness is not None and config.strictness:
-                cmdline_implicit.append('strictness_%s' % config.strictness)
-                strictness = config.strictness
+        # Use the strictness profile only if no profile has been given
+        if config.strictness is not None and config.strictness:
+            cmdline_implicit.append('strictness_%s' % config.strictness)
+            strictness = config.strictness
 
         # the profile path is
         #   * anything provided as an argument

--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -24,6 +24,7 @@ def build_manager():
     manager.add(soc.BooleanSetting('doc_warnings', default=None))
     manager.add(soc.BooleanSetting('test_warnings', default=None))
     manager.add(soc.BooleanSetting('no_style_warnings', default=None))
+    manager.add(soc.BooleanSetting('member_warnings', default=None))
     manager.add(soc.BooleanSetting('full_pep8', default=None))
     manager.add(soc.IntegerSetting('max_line_length', default=None))
 
@@ -136,6 +137,12 @@ def build_command_line_source(prog=None, description='Performs static analysis o
             'flags': ['-8', '--no-style-warnings'],
             'help': 'Don\'t create any warnings about style. This disables the'
                     ' PEP8 tool and similar checks for formatting.',
+        },
+        'member_warnings': {
+            'flags': ['-m', '--member-warnings'],
+            'help': 'Attempt to warn when code tries to access an attribute of a '
+                    'class or member of a module which does not exist. This is disabled '
+                    'by default as it tends to be quite inaccurate.'
         },
         'full_pep8': {
             'flags': ['-F', '--full-pep8'],

--- a/prospector/profiles/profiles/default.yaml
+++ b/prospector/profiles/profiles/default.yaml
@@ -2,3 +2,4 @@ strictness: medium
 doc-warnings: false
 test-warnings: false
 autodetect: true
+member-warnings: false

--- a/prospector/profiles/profiles/member_warnings.yaml
+++ b/prospector/profiles/profiles/member_warnings.yaml
@@ -1,0 +1,6 @@
+allow-shorthand: false
+
+pylint:
+  enable:
+    - no-member
+    - no-name-in-module

--- a/prospector/profiles/profiles/no_member_warnings.yaml
+++ b/prospector/profiles/profiles/no_member_warnings.yaml
@@ -1,0 +1,6 @@
+allow-shorthand: false
+
+pylint:
+  disable:
+    - no-member
+    - no-name-in-module


### PR DESCRIPTION
The sad fact is that pylint's member warnings are wrong more often than they are right. As Prospector's aim is to reduce noise and make it really easy to get useful results, it seems pragmatic to simply turn those warnings off.

It can be turned on again in profiles with the member-warnings setting or the --member-warnings command line flag, but the default will now not include those warnings.