### PR TITLE
Load profiles from .prospector directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Prospector Changelog
 =======
 
+## Version 0.10
+* [#32](https://github.com/landscapeio/prospector/issues/32) and [#108](https://github.com/landscapeio/prospector/pull/108) Added a new 'xunit' output formatter for tools and services which integrate with this format (thanks to [lfrodrigues](https://github.com/lfrodrigues))
+* Added a new built-in profile called 'flake8' for people who want to mimic the behaviour of 'flake8' using prospector.
+
 ## Version 0.9.10
 * The profile validator would load any file whose name was a subset of '.prospector.yaml' due to using the incorrect comparison operator.
 * Fixing a crash when using an empty `ignore-patterns` list in a profile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Prospector Changelog
 =======
 
 ## Version 0.10
+* [#112](https://github.com/landscapeio/prospector/issues/112) Profiles will now also be autoloaded from directories named `.prospector`.
 * [#32](https://github.com/landscapeio/prospector/issues/32) and [#108](https://github.com/landscapeio/prospector/pull/108) Added a new 'xunit' output formatter for tools and services which integrate with this format (thanks to [lfrodrigues](https://github.com/lfrodrigues))
 * Added a new built-in profile called 'flake8' for people who want to mimic the behaviour of 'flake8' using prospector.
 

--- a/prospector/__pkginfo__.py
+++ b/prospector/__pkginfo__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 9, 10)
+__version_info__ = (0, 9, 11)
 __version__ = '.'.join(map(str, __version_info__))

--- a/prospector/__pkginfo__.py
+++ b/prospector/__pkginfo__.py
@@ -1,2 +1,2 @@
-__version_info__ = (0, 9, 11)
+__version_info__ = (0, 10)
 __version__ = '.'.join(map(str, __version_info__))

--- a/prospector/formatters/__init__.py
+++ b/prospector/formatters/__init__.py
@@ -1,4 +1,4 @@
-from prospector.formatters import json, text, grouped, emacs, yaml, pylint
+from prospector.formatters import json, text, grouped, emacs, yaml, pylint, xunit
 
 
 __all__ = (
@@ -13,4 +13,5 @@ FORMATTERS = {
     'emacs': emacs.EmacsFormatter,
     'yaml': yaml.YamlFormatter,
     'pylint': pylint.PylintFormatter,
+    'xunit': xunit.XunitFormatter,
 }

--- a/prospector/formatters/xunit.py
+++ b/prospector/formatters/xunit.py
@@ -1,0 +1,58 @@
+from prospector.formatters.base import Formatter
+from xml.dom.minidom import Document
+
+
+class XunitFormatter(Formatter):
+
+    """
+    This formatter outputs messages in the Xunit xml format, which is used by several
+    CI tools to parse output. This formatter is therefore a compatability shim between tools built
+    to use Xunit and prospector itself.
+    """
+
+    def render(self, summary=True, messages=True, profile=False):
+        xml_doc = Document()
+
+        testsuite_el = xml_doc.createElement('testsuite')
+        testsuite_el.setAttribute('errors', str(self.summary['message_count']))
+        testsuite_el.setAttribute('failures', '0')
+        testsuite_el.setAttribute('name', 'prospector-%s' % '-'.join(self.summary['tools']))
+        testsuite_el.setAttribute('tests', str(self.summary['message_count']))
+        testsuite_el.setAttribute('time', str(self.summary['time_taken']))
+        xml_doc.appendChild(testsuite_el)
+
+        prop_el = xml_doc.createElement('properties')
+        testsuite_el.appendChild(prop_el)
+
+        sysout_el = xml_doc.createElement('system-out')
+        sysout_el.appendChild(xml_doc.createCDATASection(''))
+        testsuite_el.appendChild(sysout_el)
+
+        syserr_el = xml_doc.createElement('system-err')
+        syserr_el.appendChild(xml_doc.createCDATASection(''))
+        testsuite_el.appendChild(syserr_el)
+
+        for message in sorted(self.messages):
+            testcase_el = xml_doc.createElement('testcase')
+            testcase_el.setAttribute('name', '%s-%s' % (message.location.path, message.location.line))
+
+            failure_el = xml_doc.createElement('error')
+            failure_el.setAttribute('message', message.message.strip())
+            failure_el.setAttribute('type', '%s Error' % message.source)
+            template = '%(path)s:%(line)s: [%(code)s(%(source)s), %(function)s] %(message)s'
+            cdata = template % {
+                'path': message.location.path,
+                'line': message.location.line,
+                'source': message.source,
+                'code': message.code,
+                'function': message.location.function,
+                'message': message.message.strip()
+            }
+            failure_el.appendChild(xml_doc.createCDATASection(cdata))
+
+            testcase_el.appendChild(failure_el)
+
+            testsuite_el.appendChild(testcase_el)
+
+        return xml_doc.toprettyxml(encoding='utf-8')
+

--- a/prospector/profiles/__init__.py
+++ b/prospector/profiles/__init__.py
@@ -14,4 +14,8 @@ AUTO_LOADED_PROFILES = list(os.path.join(*parts) for parts in (
     ('prospector', '.prospector.yml'),
     ('prospector', 'prospector.yaml'),
     ('prospector', 'prospector.yml'),
+    ('.prospector', '.prospector.yaml'),
+    ('.prospector', '.prospector.yml'),
+    ('.prospector', 'prospector.yaml'),
+    ('.prospector', 'prospector.yml'),
 ))

--- a/prospector/profiles/profiles/flake8.yaml
+++ b/prospector/profiles/profiles/flake8.yaml
@@ -1,0 +1,19 @@
+allow-shorthand: false
+
+pylint:
+  run: false
+
+pyroma:
+  run: false
+
+frosted:
+  run: false
+
+vulture:
+  run: false
+
+dodgy:
+  run: false
+
+pep257:
+  run: false

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ _INSTALL_REQUIRES = [
     'pylint-django>=0.6',
     'pylint-plugin-utils>=0.2.3',
     'pylint-common>=0.2.1',
-    'requirements-detector>=0.3',
+    'requirements-detector>=0.4',
     'setoptconf>=0.2.0',
     'dodgy>=0.1.6',
     'pyyaml',


### PR DESCRIPTION
Fixes #112 
This makes prospector also search in a directory named `.prospector` (in addition to `prospector`) when searching for profiles. This is the previous documented behaviour.