### PR TITLE
Fix #118: Always return `str` objects from formatter.render

### DIFF
--- a/prospector/formatters/xunit.py
+++ b/prospector/formatters/xunit.py
@@ -54,5 +54,4 @@ class XunitFormatter(Formatter):
 
             testsuite_el.appendChild(testcase_el)
 
-        return xml_doc.toprettyxml(encoding='utf-8')
-
+        return xml_doc.toprettyxml()

--- a/prospector/formatters/yaml.py
+++ b/prospector/formatters/yaml.py
@@ -28,6 +28,5 @@ class YamlFormatter(Formatter):
             output,
             indent=2,
             default_flow_style=False,
-            encoding='utf-8',
             allow_unicode=True,
         )

--- a/tests/test_formatter_types.py
+++ b/tests/test_formatter_types.py
@@ -19,4 +19,5 @@ class FormatterTypeTest(TestCase):
                                     inherit_order=['horse'])
         for formatter_name, formatter in FORMATTERS.items():
             formatter_instance = formatter(summary, [], profile)
-            self.assertIsInstance(formatter_instance.render(True, True, False), str)
+            self.assertIsInstance(formatter_instance.render(True, True, False),
+                                  str)

--- a/tests/test_formatter_types.py
+++ b/tests/test_formatter_types.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+from prospector.formatters import FORMATTERS
+from prospector.profiles.profile import ProspectorProfile
+import datetime
+
+
+class FormatterTypeTest(TestCase):
+    def test_formatter_types(self):
+        summary = {'started': datetime.datetime(2014, 1, 1),
+                   'completed': datetime.datetime(2014, 1, 1),
+                   'message_count': 0,
+                   'time_taken': '0',
+                   'libraries': [],
+                   'strictness': 'veryhigh',
+                   'profiles': '',
+                   'tools': []}
+        profile = ProspectorProfile(name='horse',
+                                    profile_dict={},
+                                    inherit_order=['horse'])
+        for formatter_name, formatter in FORMATTERS.items():
+            with self.subTest(formatter=formatter_name):
+                formatter_instance = formatter(summary, [], profile)
+                self.assertIsInstance(formatter_instance.render(True, True, False), str)

--- a/tests/test_formatter_types.py
+++ b/tests/test_formatter_types.py
@@ -18,6 +18,5 @@ class FormatterTypeTest(TestCase):
                                     profile_dict={},
                                     inherit_order=['horse'])
         for formatter_name, formatter in FORMATTERS.items():
-            with self.subTest(formatter=formatter_name):
-                formatter_instance = formatter(summary, [], profile)
-                self.assertIsInstance(formatter_instance.render(True, True, False), str)
+            formatter_instance = formatter(summary, [], profile)
+            self.assertIsInstance(formatter_instance.render(True, True, False), str)


### PR DESCRIPTION
Under both Python 2 and Python 3, the output stream (actually
always `sys.stdout` in practice) is opened in text mode, and so
responsibility for handling the encoding lies with `.write`.

The XUnit and YAML backends were previously explicitly forcing an
encoding, which under Python 3 would mean `bytes` objects were
generated. This makes `sys.stdout` remarkably unhappy.

Solved by just removing the explicit encodings. Test case included.

Footnote: first contribution! Hopefully this is up to snuff?