### PR TITLE
Load pylint plugins specified in external config

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -120,6 +120,7 @@ class PylintTool(ToolBase):
         with stdout_wrapper(self._hide_stdout):
             linter.load_default_plugins()
             linter.load_file_configuration(pylintrc)
+            linter.load_plugin_modules(linter.config.load_plugins)
 
     def configure(self, prospector_config, found_files):
 


### PR DESCRIPTION
This patch ensure the linter loads the pylint plugins specified in the external configuration (pylintrc) when it is used. This is required to load the pylint_django plugin for example.