### PR TITLE
Load plugins from pylintrc as well

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -122,6 +122,8 @@ class PylintTool(ToolBase):
         with stdout_wrapper(self._hide_stdout):
             linter.load_default_plugins()
             linter.load_file_configuration(pylintrc)
+            if hasattr(linter.config, 'load_plugins'):
+                linter.load_plugin_modules(linter.config.load_plugins)
 
     def configure(self, prospector_config, found_files):
 


### PR DESCRIPTION
Currently, if there is a [MASTER] load-plugins statement in pylintrc, the plugins will not get loaded.