### PR TITLE
fix(suppression.py): file encoding problem

### DIFF
--- a/prospector/suppression.py
+++ b/prospector/suppression.py
@@ -19,9 +19,11 @@ in the file:
 This module's job is to attempt to collect all of these methods into
 a single coherent list of error suppression locations.
 """
-from collections import defaultdict
 import os
 import re
+import codecs
+from collections import defaultdict
+from prospector.autodetect import determine_pyfile_encoding
 
 
 _FLAKE8_IGNORE_FILE = re.compile(r'flake8[:=]\s*noqa', re.IGNORECASE)
@@ -89,7 +91,8 @@ def get_suppressions(relative_filepaths, root, messages):
     # first deal with 'noqa' style messages
     for filepath in relative_filepaths:
         abspath = os.path.join(root, filepath)
-        with open(abspath) as modulefile:
+        encoding = determine_pyfile_encoding(abspath, default='utf8')
+        with codecs.open(abspath, encoding=encoding) as modulefile:
             file_contents = modulefile.readlines()
         ignore_file, ignore_lines = get_noqa_suppressions(file_contents)
         if ignore_file:


### PR DESCRIPTION
    Traceback (most recent call last):
      File "C:\python34\Lib\runpy.py", line 170, in _run_module_as_main
        "__main__", mod_spec)
      File "C:\python34\Lib\runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "C:project\__data__\venv\Scripts\prospector.exe\__main__.py", line 9, in <module>
      File "C:project\__data__\venv\lib\site-packages\prospector\run.py", line 143, in main
        prospector.execute()
      File "C:project\__data__\venv\lib\site-packages\prospector\run.py", line 76, in execute
        messages = self.process_messages(found_files, messages)
      File "C:project\__data__\venv\lib\site-packages\prospector\run.py", line 36, in process_messages
        return postfilter.filter_messages(filepaths, self.config.workdir, messages)
      File "C:project\__data__\venv\lib\site-packages\prospector\postfilter.py", line 23, in filter_messages
        paths_to_ignore, lines_to_ignore, messages_to_ignore = get_suppressions(relative_filepaths, root, messages)
      File "C:project\__data__\venv\lib\site-packages\prospector\suppression.py", line 93, in get_suppressions
        file_contents = modulefile.readlines()
      File "C:project\__data__\venv\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 1111: character maps to <undefined>