### PR TITLE
Fix misnamed output-format in docs.

### DIFF
--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -42,7 +42,7 @@ Example
 
 Here is an example profile::
   
-    output_format: json
+    output-format: json
 
     strictness: medium
     test-warnings: true


### PR DESCRIPTION
The current code is reading from 'output-format', not 'output_format'.