### PR TITLE
Make member-warnings a valid setting

### DIFF
--- a/prospector/tools/profile_validator/__init__.py
+++ b/prospector/tools/profile_validator/__init__.py
@@ -24,7 +24,7 @@ class ProfileValidationTool(ToolBase):
     )
     ALL_SETTINGS = LIST_SETTINGS + (
         'strictness', 'autodetect', 'max-line-length',
-        'output-format', 'doc-warnings', 'test-warnings',
+        'output-format', 'doc-warnings', 'test-warnings', 'member-warnings',
         'requirements',  # bit of a grim hack; prospector does not use this but Landscape does
     )
 


### PR DESCRIPTION
The profile-validator tool reports that `member-warnings` is not a valid setting.