### PR TITLE
bugfix exception handler for pep257's AllError

### DIFF
--- a/prospector/tools/pep257/__init__.py
+++ b/prospector/tools/pep257/__init__.py
@@ -57,6 +57,9 @@ class Pep257Tool(ToolBase):
                     )
                     messages.append(message)
             except AllError as exc:
+                # pep257's Parser.parse_all method raises AllError when an
+                # attempt to analyze the __all__ definition has failed.  This
+                # occurs when __all__ is too complexed to be parsed.
                 location = Location(
                     path=code_file,
                     module=None,
@@ -69,7 +72,7 @@ class Pep257Tool(ToolBase):
                     source='pep257',
                     code='D000',
                     location=location,
-                    message=exc.message,
+                    message=exc.args[0],
                 )
                 messages.append(message)
 


### PR DESCRIPTION
Problem
-------

Since its first introduction in bee710744d878b94c06617c6749d68c1bcebd4f7, the exception
handler for pep257's AllError exception uses an invalid attribute access for ``message``::

    message=exc.message,

This mistake was likely caused by duplication of the pattern that precedes it::

    message=error.message.partition(':')[2].strip(),

Solution
--------

We may simply access this string as ``.args[0]`` for all situations.  Alternatively, str(exc) should
provide the same benefit.  AllError class initializer makes the assumption of the first argument
as a string to be concatenated with, so we continue such assumption.

Note AllError class is deceptively named -- it is used to indicate an exception occurred while parsing
``__all__``, it is not a general purpose exception. A comment has been made to indicate it as such.

Before::

	prospector -t pep257 --die-on-tool-error telnetlib3/__init__.py

	Traceback (most recent call last):
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/prospector/tools/pep257/__init__.py", line 42, in run
	    code_file,
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/pep257.py", line 1313, in check_source
	    module = parse(StringIO(source), filename)
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/pep257.py", line 259, in __call__
	    return self.parse_module()
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/pep257.py", line 409, in parse_module
	    children = list(self.parse_definitions(Module, all=True))
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/pep257.py", line 343, in parse_definitions
	    self.parse_all()
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/pep257.py", line 366, in parse_all
	    raise AllError('Could not evaluate contents of __all__. ')
	pep257.AllError: Could not evaluate contents of __all__. That means pep257 cannot decide which definitions are public. Variable __all__ should be present at most once in each file, in form `__all__ = ('a_public_function', 'APublicClass', ...)`. More info on __all__: http://stackoverflow.com/q/44834/.

	During handling of the above exception, another exception occurred:

	Traceback (most recent call last):
	  File "/Users/jquast/.pyenv/versions/telnetlib3/bin/prospector", line 11, in <module>
	    sys.exit(main())
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/prospector/run.py", line 159, in main
	    prospector.execute()
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/prospector/run.py", line 65, in execute
	    messages += tool.run(found_files)
	  File "/Users/jquast/.pyenv/versions/3.5.1/envs/telnetlib3/lib/python3.5/site-packages/prospector/tools/pep257/__init__.py", line 72, in run
	    message=exc.message,
	AttributeError: 'AllError' object has no attribute 'message'

After::

	Check Information
	=================
		 Started: 2016-01-23 17:22:19.147560
		Finished: 2016-01-23 17:22:19.153092
	      Time Taken: 0.01 seconds
	       Formatter: grouped
		Profiles: .landscape.yml, strictness_veryhigh, no_doc_warnings, no_member_warnings
	      Strictness: from profile
	  Libraries Used:
	       Tools Run: pep257
	  Messages Found: 0

Note the profile ``strictness_veryhigh`` ignores code ``D000`` for pep257, of which this error is classified,
and is the reason it was filtered away.