### PR TITLE
sort with_everything deps for _OPTIONAL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,8 @@ _OPTIONAL = {
     'with_pyroma': ('pyroma>=1.6,<2.0',),
     'with_pep257': (),  # note: this is no longer optional, so this option will be removed in a future release
 }
-_OPTIONAL['with_everything'] = [req for req_list in _OPTIONAL.values() for req in req_list]
-
+with_everything = [req for req_list in _OPTIONAL.values() for req in req_list]
+_OPTIONAL['with_everything'] = sorted(with_everything)
 
 if os.path.exists('README.rst'):
     _LONG_DESCRIPTION = codecs.open('README.rst', 'r', 'utf-8').read()


### PR DESCRIPTION
Patch from Debian out of reproducible builds: the list comprehension for _OPTIONAL['with_everything'] iterates over the previous dict entries non-deterministically, and the resulting entry order differs if build on different archs. And setuptools not yet sorts for egg.info/requires.txt. If you would like to take that in, welcome.