### PR TITLE
tools: fix encoding handling for mccabe/pep257/vulture

### DIFF
--- a/prospector/tools/mccabe/__init__.py
+++ b/prospector/tools/mccabe/__init__.py
@@ -6,6 +6,7 @@ from mccabe import PathGraphingAstVisitor
 
 from prospector.message import Location, Message
 from prospector.tools.base import ToolBase
+from prospector.encoding import read_py_file, CouldNotHandleEncoding
 
 
 __all__ = (
@@ -31,8 +32,12 @@ class McCabeTool(ToolBase):
 
         for code_file in found_files.iter_module_paths():
             try:
+                try:
+                    contents = read_py_file(code_file)
+                except CouldNotHandleEncoding:
+                    continue
                 tree = ast.parse(
-                    open(code_file, 'r').read(),
+                    contents,
                     filename=code_file,
                 )
             except SyntaxError as e:

--- a/prospector/tools/pep257/__init__.py
+++ b/prospector/tools/pep257/__init__.py
@@ -14,6 +14,7 @@ if hasattr(pydocstyle, 'log'):  # noqa
 from pydocstyle import PEP257Checker, AllError
 from prospector.message import Location, Message
 from prospector.tools.base import ToolBase
+from prospector.encoding import read_py_file, CouldNotHandleEncoding
 
 
 __all__ = (
@@ -37,8 +38,12 @@ class Pep257Tool(ToolBase):
 
         for code_file in found_files.iter_module_paths():
             try:
+                try:
+                    contents = read_py_file(code_file)
+                except CouldNotHandleEncoding:
+                    continue
                 for error in checker.check_source(
-                        open(code_file, 'r').read(),
+                        contents,
                         code_file,
                 ):
                     location = Location(

--- a/prospector/tools/vulture/__init__.py
+++ b/prospector/tools/vulture/__init__.py
@@ -1,6 +1,7 @@
 from vulture import Vulture
 from prospector.message import Location, Message
 from prospector.tools.base import ToolBase
+from prospector.encoding import read_py_file, CouldNotHandleEncoding
 
 
 class ProspectorVulture(Vulture):
@@ -15,7 +16,10 @@ class ProspectorVulture(Vulture):
         # argument is here to explicitly acknowledge that we
         # are overriding the Vulture.scavenge method.
         for module in self._files.iter_module_paths():
-            module_string = open(module).read()
+            try:
+                module_string = read_py_file(module)
+            except CouldNotHandleEncoding:
+                continue
             self.file = module
             self.scan(module_string)
 


### PR DESCRIPTION
Extend the use of `prospector.encoding.read_py_file` as per support for the dodgy tool.