### PR TITLE
vulture: Adapt for internal API in versions 0.9+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ _CLASSIFIERS = (
 
 _OPTIONAL = {
     'with_frosted': ('frosted>=1.4.1',),
-    'with_vulture': ('vulture>=0.6',),
+    'with_vulture': ('vulture>=0.10',),
     'with_pyroma': ('pyroma>=2.0.2',),
 }
 with_everything = [req for req_list in _OPTIONAL.values() for req in req_list]


### PR DESCRIPTION
Vulture now only sets self.unused_funcs etc to be the name
of the unused thing and does not specify a file or line. Not ideal
for us, but at least wrap it in something so that we get useful
error messages instead of "exception raised"

Fixes #180