### PR TITLE
vulture: Adapt for internal API in versions 0.9+

### DIFF
--- a/prospector/tools/vulture/__init__.py
+++ b/prospector/tools/vulture/__init__.py
@@ -27,7 +27,7 @@ class ProspectorVulture(Vulture):
                 ))
                 continue
             self.file = module
-            self.scan(module_string)
+            self.scan(module_string, self.file)
 
     def get_messages(self):
         all_items = (
@@ -40,7 +40,7 @@ class ProspectorVulture(Vulture):
         vulture_messages = []
         for code, template, items in all_items:
             for item in items:
-                loc = Location(item.file, None, None, item.lineno, -1)
+                loc = Location(item.filename, None, None, item.lineno, -1)
                 message_text = template % item
                 message = Message('vulture', code, loc, message_text)
                 vulture_messages.append(message)


### PR DESCRIPTION
Vulture now only sets self.unused_funcs etc to be the name
of the unused thing and does not specify a file or line. Not ideal
for us, but at least wrap it in something so that we get useful
error messages instead of "exception raised"

Fixes #180
