### PR TITLE
Added html formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Prospector Changelog
 =======
 
+# Version 0.13.0
+* Added HTML formatter
+
 # Version 0.12.1
 * Fixed a crash in the profile_validator tool if an empty profile was found
 * [#178](https://github.com/landscapeio/prospector/pull/178) Long paths no longer cause crash in Windows.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@ Contributors
 * Jason Simeone ([@jayclassless](https://github.com/jayclassless))
 * Jeff Quast ([@jquast](https://github.com/jquast))
 * Sam Spilsbury ([@smspillaz](https://github.com/smspillaz))
+* Jose Antonio Perdiguero ([@PeRDy](https://github.com/PeRDy))

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include prospector/blender_combinations.yaml
 include prospector/profiles/profiles/*.yaml
+graft prospector/formatters/templates

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,6 +47,9 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 +-------------+----------------------------------------------------------------------------+
 | ``xunit``   | | Same as JSON except produces xunit compatile XML output.                 |
 +-------------+----------------------------------------------------------------------------+
+| ``html``    | | Produces a bootstrap-based HTML output of the messages, summary and      |
+|             | | optionally the profile used.                                             |
++-------------+----------------------------------------------------------------------------+
 | ``text``    | | The default output format, a simple human readable format.               |
 +-------------+----------------------------------------------------------------------------+
 

--- a/prospector/__pkginfo__.py
+++ b/prospector/__pkginfo__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version_info__ = (0, 12, 1)
+__version_info__ = (0, 13, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/prospector/encoding.py
+++ b/prospector/encoding.py
@@ -16,7 +16,8 @@ def read_py_file(filepath):
         # see https://docs.python.org/3/library/tokenize.html#tokenize.detect_encoding
         # first just see if the file is properly encoded
         try:
-            tokenize.detect_encoding(filepath)
+            with open(filepath, 'rb') as f:
+                tokenize.detect_encoding(f.readline)
         except SyntaxError as err:
             # this warning is issued:
             #   (1) in badly authored files (contains non-utf8 in a comment line)

--- a/prospector/formatters/__init__.py
+++ b/prospector/formatters/__init__.py
@@ -1,4 +1,5 @@
-from prospector.formatters import json, text, grouped, emacs, yaml, pylint, xunit, vscode
+# -*- coding: utf-8 -*-
+from prospector.formatters import json, text, grouped, emacs, yaml, pylint, xunit, vscode, html
 
 
 __all__ = (
@@ -15,4 +16,5 @@ FORMATTERS = {
     'pylint': pylint.PylintFormatter,
     'xunit': xunit.XunitFormatter,
     'vscode': vscode.VSCodeFormatter,
+    'html': html.HTMLFormatter,
 }

--- a/prospector/formatters/html.py
+++ b/prospector/formatters/html.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import os
+
+from jinja2 import FileSystemLoader
+from jinja2.environment import Environment
+
+from prospector.formatters.base import Formatter
+
+__all__ = (
+    'HTMLFormatter',
+)
+
+
+# pylint: disable=unnecessary-lambda
+
+
+class HTMLFormatter(Formatter):
+    TEMPLATE_PATHS = (
+        '.',
+        os.path.join(os.path.dirname(__file__), 'templates'),
+    )
+
+    TEMPLATE = 'formatter.html'
+
+    def render_template(self, **context):
+        """
+        Render HTML using Jinja2 template.
+
+        :param context: Context to render template.
+        :return: Rendered template.
+        """
+        loader = FileSystemLoader(self.TEMPLATE_PATHS)
+        env = Environment(loader=loader)
+        return env.get_template(self.TEMPLATE).render(**context)
+
+    def render(self, summary=True, messages=True, profile=False):
+        context = {}
+        if messages and self.messages:  # if there are no messages, don't render an empty header
+            context['messages'] = self.messages
+        if profile:
+            context['profile'] = self.profile.as_yaml().strip()
+        if summary:
+            context['summary'] = {k: v for k, v in self.summary.items() if v}
+
+        return self.render_template(**context)

--- a/prospector/formatters/templates/formatter.html
+++ b/prospector/formatters/templates/formatter.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>Prospector</title>
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/themes/prism.min.css">
+
+  <style type="text/css">
+  </style>
+</head>
+<body>
+<div class="container">
+  {% if summary %}
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="panel-title">
+            <h3>Summary</h3>
+          </div>
+        </div>
+        <ul class="list-group">
+          {% for key, value in summary|dictsort %}
+          {% if value %}
+          <li class="list-group-item">
+            <h4 class="list-group-item-heading">{{ key|replace('_', ' ')|title }}</h4>
+            {% if value is sequence and not value is string %}
+            <p class="list-group-item-text">{{ value|join(', ') }}</p>
+            {% else %}
+            <p class="list-group-item-text">{{ value }}</p>
+            {% endif %}
+          </li>
+          {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if messages %}
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="panel-title">
+            <h3>Messages</h3>
+          </div>
+        </div>
+        <table class="table">
+          <tr>
+            <th>Path</th>
+            <th>Line</th>
+            <th>Character</th>
+            <th>Code</th>
+            <th>Message</th>
+            <th>Source</th>
+          </tr>
+          {% for message in messages|sort(attribute='location.path') %}
+          <tr>
+            <td>{{ message.location.path }}</td>
+            <td>{{ message.location.line }}</td>
+            <td>{{ message.location.character }}</td>
+            <td>{{ message.code }}</td>
+            <td>{{ message.message }}</td>
+            <td>{{ message.source }}</td>
+          </tr>
+          {% endfor %}
+        </table>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if profile %}
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div class="panel-title">
+            <h3>Profile</h3>
+          </div>
+        </div>
+        <div class="panel-body">
+          <pre><code class="language-yaml">{{ profile|trim }}</code></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</div>
+<script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+<script type="text/javascript"
+        src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-core.min.js"></script>
+<script type="text/javascript"
+        src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-yaml.min.js"></script>
+</body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ _INSTALL_REQUIRES = [
     'pycodestyle>=2.0.0',
     'pep8-naming>=0.3.3',
     'pydocstyle>=0.1',
+    'Jinja2>=2.8',
 ]
 
 _PACKAGE_DATA = {

--- a/tests/test_formatter_types.py
+++ b/tests/test_formatter_types.py
@@ -1,7 +1,10 @@
+# -*- coding: utf-8 -*-
+import datetime
 from unittest import TestCase
+
+import six
 from prospector.formatters import FORMATTERS
 from prospector.profiles.profile import ProspectorProfile
-import datetime
 
 
 class FormatterTypeTest(TestCase):
@@ -20,4 +23,4 @@ class FormatterTypeTest(TestCase):
         for formatter_name, formatter in FORMATTERS.items():
             formatter_instance = formatter(summary, [], profile)
             self.assertIsInstance(formatter_instance.render(True, True, False),
-                                  str)
+                                  six.string_types)


### PR DESCRIPTION
This changes added a new formatter to prospector current set. This format is a basic html using bootstrap to create an acceptable output that shows summary, messages and profile. I decided to use Jinja2 as template engine to make a more flexible html.

There is a default template in prospector/formatters/templates/formatter.html but exists the possibility of use a custom template that should be named formatter.html and must be in the same directory that prospector is running.

You can see an example of html output:
[prospector_html.zip](https://github.com/landscapeio/prospector/files/445072/prospector_html.zip)
