### PR TITLE
Fix import to match pydocstyle v.1.1.0

### DIFF
--- a/prospector/tools/pep257/__init__.py
+++ b/prospector/tools/pep257/__init__.py
@@ -13,7 +13,7 @@ if hasattr(pydocstyle, 'log'):  # noqa
         pass
     pydocstyle.log.debug = dummy_log
 
-from pydocstyle import PEP257Checker, AllError
+from pydocstyle.checker import PEP257Checker, AllError
 from prospector.message import Location, Message, make_tool_error_message
 from prospector.tools.base import ToolBase
 

--- a/prospector/tools/pep257/__init__.py
+++ b/prospector/tools/pep257/__init__.py
@@ -13,7 +13,11 @@ if hasattr(pydocstyle, 'log'):  # noqa
         pass
     pydocstyle.log.debug = dummy_log
 
-from pydocstyle.checker import PEP257Checker, AllError
+try:
+    from pydocstyle.checker import PEP257Checker, AllError  # pydocstyle >= 1.1.0
+except ImportError:
+    from pydocstyle import PEP257Checker, AllError  # pydocstyle <= 1.1.0
+
 from prospector.message import Location, Message, make_tool_error_message
 from prospector.tools.base import ToolBase
 


### PR DESCRIPTION
After recent release of `pydocstyle` package prospector fails at import `PEP257Checker`.
This PR corrects import path.
