### PR TITLE
Using pylint 1.5.6 as there is an error reporting issue with 1.6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if sys.version_info < (2, 7):
 _PACKAGES = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
 _INSTALL_REQUIRES = [
-    'pylint>=1.5.6',
+    'pylint==1.5.6',
     'pylint-celery>=0.3',
     'pylint-django>=0.7.2',
     'pylint-flask>=0.3',


### PR DESCRIPTION
The current setup installs pylint 1.6.x, which does not report a class of errors. Pushing this as a temporary fix until the original issue is resolved. 
Ref: https://github.com/landscapeio/prospector/issues/183
