### PR TITLE
bugfix: fix Pylint collector (broken since Pylint 1.6.0)

### DIFF
--- a/prospector/tools/pylint/collector.py
+++ b/prospector/tools/pylint/collector.py
@@ -13,6 +13,10 @@ class Collector(BaseReporter):
         self._message_store = message_store
         self._messages = []
 
+    def handle_message(self, msg):
+        location = (msg.abspath, msg.module, msg.obj, msg.line, msg.column)
+        self.add_message(msg.msg_id, location, msg.msg)
+
     def add_message(self, msg_id, location, msg):
         # (* magic is acceptable here)
         loc = Location(*location)


### PR DESCRIPTION
Since **pylint 1.6.0**, no messages are reporter via prospector. See for example #188 and #183.

It's because of this commit - https://github.com/PyCQA/pylint/commit/dc071966398d26159773ec627c954cf651d3036e - which removes `handle_message` body in `BaseReporter`.

This pull requests fixes the issue.
