### PR TITLE
Support pylint 2.0 UnknownMessage rename to UnknownMessageError

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -4,7 +4,10 @@ import re
 import sys
 import os
 from pylint.config import find_pylintrc
-from pylint.utils import UnknownMessage
+try:
+    from pylint.utils import UnknownMessage
+except ImportError:
+    from pylint.utils import UnknownMessageError as UnknownMessage
 from prospector.message import Message, Location
 from prospector.tools.base import ToolBase
 from prospector.tools.pylint.collector import Collector

--- a/prospector/tools/pylint/collector.py
+++ b/prospector/tools/pylint/collector.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 from pylint.reporters import BaseReporter
-from pylint.utils import UnknownMessage
+try:
+    from pylint.utils import UnknownMessage
+except ImportError:
+    from pylint.utils import UnknownMessageError as UnknownMessage
 from prospector.message import Location, Message
 
 


### PR DESCRIPTION
Pylint 2.0 switched to using UnknownMessageError (see [commit](https://github.com/PyCQA/pylint/commit/f63f165dbcc87fd792916c47f4d5c5e7796f00d0)). 

This PR fixes this.