### PR TITLE
Fix missing 'UnknownMessage' exception

### DIFF
--- a/prospector/exceptions.py
+++ b/prospector/exceptions.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-
+try:
+    from pylint.utils import UnknownMessage as UnknownMessageError
+except ImportError:
+    from pylint.exceptions import UnknownMessageError
 
 class FatalProspectorException(Exception):
 

--- a/prospector/exceptions.py
+++ b/prospector/exceptions.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
+
+# We are trying to handle pylint changes in their exception classes
 try:
+    # pylint < 1.7
     from pylint.utils import UnknownMessage as UnknownMessageError
 except ImportError:
+    # pylint >= 1.7
     from pylint.exceptions import UnknownMessageError
 
 class FatalProspectorException(Exception):

--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -4,7 +4,7 @@ import re
 import sys
 import os
 from pylint.config import find_pylintrc
-from pylint.utils import UnknownMessage
+from prospector.exceptions import UnknownMessageError
 from prospector.message import Message, Location
 from prospector.tools.base import ToolBase
 from prospector.tools.pylint.collector import Collector
@@ -41,7 +41,7 @@ class PylintTool(ToolBase):
             try:
                 linter.disable(msg_id)
             # pylint: disable=pointless-except
-            except UnknownMessage:
+            except UnknownMessageError:
                 # If the msg_id doesn't exist in PyLint any more,
                 # don't worry about it.
                 pass

--- a/prospector/tools/pylint/collector.py
+++ b/prospector/tools/pylint/collector.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from pylint.reporters import BaseReporter
-from pylint.utils import UnknownMessage
+from prospector.exceptions import UnknownMessageError
 from prospector.message import Location, Message
 
 
@@ -20,7 +20,7 @@ class Collector(BaseReporter):
         # more user-friendly symbol
         try:
             msg_data = self._message_store.check_message_id(msg_id)
-        except UnknownMessage:
+        except UnknownMessageError:
             # this shouldn't happen, as all pylint errors should be
             # in the message store, but just in case we'll fall back
             # to using the code.


### PR DESCRIPTION
The recent 1.7 version of pylint moved the exceptions to a different
submodule and this ensures everything works as expected.

Since there's been no activity on #205, I took it upon myself to update it as suggested there.
I did end up moving the pylint exception to the `prospector.exceptions` submodule, as I found it odd to sprinkle a `try .. except` everywhere.

I did not update the `_INSTALL_REQUIRES` in `setup.py` to up the version of pylint to `pylint>=1.7` or so. I think it should probably be done too.

This should also resolve #206.