### PR TITLE
pep257: Support pydocstyle >= 2.0.0

### DIFF
--- a/prospector/tools/pep257/__init__.py
+++ b/prospector/tools/pep257/__init__.py
@@ -14,9 +14,12 @@ if hasattr(pydocstyle, 'log'):  # noqa
     pydocstyle.log.debug = dummy_log
 
 try:
-    from pydocstyle.checker import PEP257Checker, AllError  # pydocstyle >= 1.1.0
+    from pydocstyle.checker import ConventionChecker as PEP257Checker, AllError  # pydocstyle >= 2.0.0
 except ImportError:
-    from pydocstyle import PEP257Checker, AllError  # pydocstyle <= 1.1.0
+    try:
+        from pydocstyle.checker import PEP257Checker, AllError  # pydocstyle >= 1.1.0
+    except ImportError:
+        from pydocstyle import PEP257Checker, AllError  # pydocstyle <= 1.1.0
 
 from prospector.message import Location, Message, make_tool_error_message
 from prospector.tools.base import ToolBase

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ _INSTALL_REQUIRES = [
     'pyflakes>=0.8.1',
     'pycodestyle==2.0.0',
     'pep8-naming>=0.3.3',
-    'pydocstyle==1.0.0',
+    'pydocstyle>=1.0.0',
 ]
 
 _PACKAGE_DATA = {


### PR DESCRIPTION
This was relatively trivial to support and allows us to use prospector concurrently with tools that require pydocstyle 2.0.0