### PR TITLE
Create __main__.py

### DIFF
--- a/prospector/__main__.py
+++ b/prospector/__main__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
+from prospector.run import main
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
I prefer not to add the `Scripts` folder to my PATH.

- adding a `__main__.py` allows one to call:

```
python -m prospector <args>
```

