### PR TITLE
Rename pep8/pep257 to pycodestyle/pydocstyle everywhere

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -21,12 +21,12 @@ pylint:
     - missing-docstring
     - star-args
 
-pep8:
+pycodestyle:
   full: true
   disable:
     - E126
 
-pep257:
+pydocstyle:
   disable:
     - D100
     - D101

--- a/prospector/blender.py
+++ b/prospector/blender.py
@@ -39,7 +39,7 @@ def blend_line(messages, blend_combos=None):
 
         # note: we use 'found=True' here rather than a simple break/for-else
         # because this allows the same message to be put into more than one
-        # 'bucket'. This means that the same message from pep8 can 'subsume'
+        # 'bucket'. This means that the same message from pycodestyle can 'subsume'
         # two from pylint, for example.
 
         if not found:
@@ -61,13 +61,13 @@ def blend_line(messages, blend_combos=None):
         if blend_list[0] not in blended:
             # We may have already added this message if it represents
             # several messages in other tools which are not being run -
-            # for example, pylint missing-docstring is blended with pep257 D100, D101
+            # for example, pylint missing-docstring is blended with pydocstyle D100, D101
             # and D102, but should not appear 3 times!
             blended.append(blend_list[0])
 
         # Some messages from a tool point out an error that in another tool is handled by two
         # different errors or more. For example, pylint emits the same warning (multiple-statements)
-        # for "two statements on a line" separated by a colon and a semi-colon, while pep8 has E701
+        # for "two statements on a line" separated by a colon and a semi-colon, while pycodestyle has E701
         # and E702 for those cases respectively. In this case, the pylint error will not be 'blended' as
         # it will appear in two blend_lists. Therefore we mark anything not taken from the blend list
         # as "consumed" and then filter later, to avoid such cases.

--- a/prospector/blender_combinations.yaml
+++ b/prospector/blender_combinations.yaml
@@ -15,7 +15,7 @@ combinations:
         - dodgy: diff
         - pylint: syntax-error
         - pyflakes: F999
-        - pep8: E901
+        - pycodestyle: E901
         - mccabe: MC0000
         - frosted: E402
 
@@ -31,8 +31,8 @@ combinations:
         - frosted: E307
 
     -   # Mixed tabs and spaces
-        - pep257: D206
-        - pep8: E101
+        - pydocstyle: D206
+        - pycodestyle: E101
         - pylint: indentation-mixture
 
     -   # Import from __future__ not first import
@@ -41,55 +41,55 @@ combinations:
         - frosted: E207
 
     -   # Line too long
-        - pep8: E501
+        - pycodestyle: E501
         - pylint: line-too-long
 
     -   # Trailing whitespace
-        - pep8: W291
+        - pycodestyle: W291
         - pylint: trailing-whitespace
 
     -   # Blank line contains whitespace
-        - pep8: W293
+        - pycodestyle: W293
         - pylint: trailing-whitespace
 
     -   # No newline at end of file
-        - pep8: W292
+        - pycodestyle: W292
         - pylint: missing-final-newline
 
     -   # line ends with semi-colon
-        - pep8: E703
+        - pycodestyle: E703
         - pylint: unnecessary-semicolon
 
     -   # multiple statements on one line (colon)
-        - pep8: E701
+        - pycodestyle: E701
         - pylint: multiple-statements
 
     -   # multiple statements on one line (semicolon)
-        - pep8: E702
+        - pycodestyle: E702
         - pylint: multiple-statements
 
     -   # incorrect indendation
-        - pep257: D207
-        - pep8: E111
+        - pydocstyle: D207
+        - pycodestyle: E111
         - pylint: bad-indentation
 
     -   # incorrect indendation
-        - pep257: D208
-        - pep8: E111
+        - pydocstyle: D208
+        - pycodestyle: E111
         - pylint: bad-indentation
 
     -   # comma not followed by a space
-        - pep8: E231
+        - pycodestyle: E231
         - pylint: C0324
         - pylint: bad-whitespace
 
     -   # missing whitespace around operator
-        - pep8: E225
+        - pycodestyle: E225
         - pylint: C0322
         - pylint: bad-whitespace
 
     -   # missing whitespace around operator
-        - pep8: E225
+        - pycodestyle: E225
         - pylint: C0323
         - pylint: bad-whitespace
 
@@ -108,15 +108,15 @@ combinations:
         - pylint: function-redefined
 
     -   # first argument of a classmethod should be named 'cls'
-        - pep8: N804
+        - pycodestyle: N804
         - pylint: bad-classmethod-argument
 
     -   # '<>' is deprecated, use '!='
-        - pep8: W603
+        - pycodestyle: W603
         - pylint: W0331
 
     -   # backticks are deprecated, use 'repr()'
-        - pep8: W604
+        - pycodestyle: W604
         - pylint: W0333
 
     -   # Redefining name from outer scope
@@ -150,11 +150,11 @@ combinations:
         - frosted: W101
 
     -   # Spaces around keyword/paramater equals
-        - pep8: E251
+        - pycodestyle: E251
         - pylint: bad-whitespace
 
     -   # Missing space after a comma
-        - pep8: E231
+        - pycodestyle: E231
         - pylint: bad-whitespace
 
     -   # redefinition of unused %r from line %r
@@ -177,30 +177,30 @@ combinations:
         - pyflakes: F823
         - frosted: E305
 
-    -   # pep8-naming incorrectly suggests that the first argument of a metaclass __new__ method should be 'cls'
+    -   # pycodestyle-naming incorrectly suggests that the first argument of a metaclass __new__ method should be 'cls'
         - pylint: bad-mcs-classmethod-argument
-        - pep8: N804
+        - pycodestyle: N804
 
     -   # class names should be camelcase
-        - pep8: N801
+        - pycodestyle: N801
         - pylint: invalid-name
 
     -   # too complex
         - mccabe: MC0001
         - pylint: too-many-branches
 
-    -   # pep257 takes preference over pylint documentation warnings
-        - pep257: D100
+    -   # pydocstyle takes preference over pylint documentation warnings
+        - pydocstyle: D100
         - pylint: missing-docstring
 
     -
-        - pep257: D101
+        - pydocstyle: D101
         - pylint: missing-docstring
 
     -
-        - pep257: D102
+        - pydocstyle: D102
         - pylint: missing-docstring
 
     -
-        - pep257: D103
+        - pydocstyle: D103
         - pylint: missing-docstring

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -122,9 +122,9 @@ class ProspectorConfig(object):
         if config.test_warnings is not None and config.test_warnings:
             cmdline_implicit.append('test_warnings')
         if config.no_style_warnings is not None and config.no_style_warnings:
-            cmdline_implicit.append('no_pep8')
-        if config.full_pep8 is not None and config.full_pep8:
-            cmdline_implicit.append('full_pep8')
+            cmdline_implicit.append('no_pycodestyle')
+        if config.full_pycodestyle is not None and config.full_pycodestyle:
+            cmdline_implicit.append('full_pycodestyle')
         if config.member_warnings is not None and config.member_warnings:
             cmdline_implicit.append('member_warnings')
 

--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -24,7 +24,7 @@ def build_manager():
     manager.add(soc.BooleanSetting('test_warnings', default=None))
     manager.add(soc.BooleanSetting('no_style_warnings', default=None))
     manager.add(soc.BooleanSetting('member_warnings', default=None))
-    manager.add(soc.BooleanSetting('full_pep8', default=None))
+    manager.add(soc.BooleanSetting('full_pycodestyle', default=None))
     manager.add(soc.IntegerSetting('max_line_length', default=None))
 
     manager.add(soc.BooleanSetting('messages_only', default=False))
@@ -147,8 +147,8 @@ def build_command_line_source(prog=None, description='Performs static analysis o
                     'class or member of a module which does not exist. This is disabled '
                     'by default as it tends to be quite inaccurate.'
         },
-        'full_pep8': {
-            'flags': ['-F', '--full-pep8'],
+        'full_pycodestyle': {
+            'flags': ['-F', '--full-pycodestyle'],
             'help': 'Enables every PEP8 warning, so that all PEP8 style'
                     ' violations will be reported.',
         },

--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -70,7 +70,7 @@ class ProspectorProfile(object):
             }
             conf.update(profile_dict.get(tool, {}))
 
-            if self.max_line_length is not None and tool in ('pylint', 'pep8'):
+            if self.max_line_length is not None and tool in ('pylint', 'pycodestyle'):
                 conf['options']['max-line-length'] = self.max_line_length
 
             setattr(self, tool, conf)
@@ -171,7 +171,7 @@ def _simple_merge_dict(priority, base):
 def _merge_tool_config(priority, base):
     out = dict(base.items())
     for key, value in priority.items():
-        if key in ('run', 'full', 'none'):  # pep8 has extra 'full' and 'none' options
+        if key in ('run', 'full', 'none'):  # pycodestyle has extra 'full' and 'none' options
             out[key] = value
         elif key in ('options',):
             out[key] = _simple_merge_dict(value, base.get(key, {}))
@@ -220,12 +220,12 @@ def _determine_strictness(profile_dict, inherits):
     return ('strictness_%s' % strictness), True
 
 
-def _determine_pep8(profile_dict):
-    pep8 = profile_dict.get('pep8', {})
-    if pep8.get('full', False):
-        return 'full_pep8', True
-    elif pep8.get('none', False):
-        return 'no_pep8', True
+def _determine_pycodestyle(profile_dict):
+    pycodestyle = profile_dict.get('pycodestyle', {})
+    if pycodestyle.get('full', False):
+        return 'full_pycodestyle', True
+    elif pycodestyle.get('none', False):
+        return 'no_pycodestyle', True
     return None, False
 
 
@@ -253,10 +253,10 @@ def _determine_member_warnings(profile_dict):
 def _determine_implicit_inherits(profile_dict, already_inherits, shorthands_found):
     # Note: the ordering is very important here - the earlier items
     # in the list have precedence over the later items. The point of
-    # the doc/test/pep8 profiles is usually to restore items which were
+    # the doc/test/pycodestyle profiles is usually to restore items which were
     # turned off in the strictness profile, so they must appear first.
     implicit = [
-        ('pep8', _determine_pep8(profile_dict)),
+        ('pycodestyle', _determine_pycodestyle(profile_dict)),
         ('docs', _determine_doc_warnings(profile_dict)),
         ('tests', _determine_test_warnings(profile_dict)),
         ('strictness', _determine_strictness(profile_dict, already_inherits)),

--- a/prospector/profiles/profiles/doc_warnings.yaml
+++ b/prospector/profiles/profiles/doc_warnings.yaml
@@ -1,4 +1,4 @@
 allow-shorthand: false
 
-pep257:
+pydocstyle:
   run: true

--- a/prospector/profiles/profiles/flake8.yaml
+++ b/prospector/profiles/profiles/flake8.yaml
@@ -15,5 +15,5 @@ vulture:
 dodgy:
   run: false
 
-pep257:
+pydocstyle:
   run: false

--- a/prospector/profiles/profiles/full_pycodestyle.yaml
+++ b/prospector/profiles/profiles/full_pycodestyle.yaml
@@ -1,6 +1,6 @@
 allow-shorthand: false
 
-pep8:
+pycodestyle:
   run: true
   enable:
     - E101

--- a/prospector/profiles/profiles/no_doc_warnings.yaml
+++ b/prospector/profiles/profiles/no_doc_warnings.yaml
@@ -12,5 +12,5 @@ frosted:
   disable:
     - E401
 
-pep257:
+pydocstyle:
   run: false

--- a/prospector/profiles/profiles/no_pycodestyle.yaml
+++ b/prospector/profiles/profiles/no_pycodestyle.yaml
@@ -12,5 +12,5 @@ pylint:
     - C0323
     - C0324
 
-pep8:
+pycodestyle:
   run: false

--- a/prospector/profiles/profiles/strictness_high.yaml
+++ b/prospector/profiles/profiles/strictness_high.yaml
@@ -29,7 +29,7 @@ pylint:
     max-public-methods: 20
     max-line-length: 99
 
-pep8:
+pycodestyle:
   options:
     max-line-length: 99
   disable:
@@ -50,7 +50,7 @@ pyroma:
     - PYR18
     - PYR17
 
-pep257:
+pydocstyle:
   disable:
     - D400
     - D401

--- a/prospector/profiles/profiles/strictness_low.yaml
+++ b/prospector/profiles/profiles/strictness_low.yaml
@@ -2,7 +2,7 @@ allow-shorthand: false
 
 inherits:
   - strictness_medium
-  
+
 pylint:
   disable:
     - blacklisted-name
@@ -49,7 +49,7 @@ frosted:
     - E307
     - W101
 
-pep8:
+pycodestyle:
   disable:
     - E501
     - E711
@@ -62,5 +62,5 @@ pyroma:
     - PYR06
     - PYR09
 
-pep257:
+pydocstyle:
   run: false

--- a/prospector/profiles/profiles/strictness_medium.yaml
+++ b/prospector/profiles/profiles/strictness_medium.yaml
@@ -60,7 +60,7 @@ frosted:
     - E103
     - E306
 
-pep8:
+pycodestyle:
   disable:
     - E111
     - E121
@@ -71,7 +71,7 @@ pep8:
     - E126
     - E127
     - E128
-    - E133      
+    - E133
     - E201
     - E202
     - E203
@@ -119,7 +119,7 @@ pyroma:
   disable:
     - PYR04
 
-pep257:
+pydocstyle:
   disable:
     - D100
     - D101

--- a/prospector/profiles/profiles/strictness_veryhigh.yaml
+++ b/prospector/profiles/profiles/strictness_veryhigh.yaml
@@ -25,7 +25,7 @@ mccabe:
   options:
     max-complexity: 10
 
-pep8:
+pycodestyle:
   options:
     max-line-length: 79
     single-line-if-stmt: n
@@ -35,6 +35,6 @@ pyroma:
     - PYR19
     - PYR16
 
-pep257:
+pydocstyle:
   disable:
     - D000

--- a/prospector/profiles/profiles/strictness_verylow.yaml
+++ b/prospector/profiles/profiles/strictness_verylow.yaml
@@ -36,7 +36,7 @@ mccabe:
   options:
     max-complexity: 25
 
-pep8:
+pycodestyle:
   disable:
     - W601
     - W602

--- a/prospector/run.py
+++ b/prospector/run.py
@@ -60,7 +60,7 @@ class Prospector(object):
 
             try:
                 # Tools can output to stdout/stderr in unexpected places, for example,
-                # pep257 emits warnings about __all__ and as pyroma exec's the setup.py
+                # pydocstyle emits warnings about __all__ and as pyroma exec's the setup.py
                 # file, it will execute any print statements in that, etc etc...
                 with capture_output(hide=not self.config.direct_tool_stdout) as capture:
                     messages += tool.run(found_files)

--- a/prospector/suppression.py
+++ b/prospector/suppression.py
@@ -33,7 +33,7 @@ _PYLINT_SUPPRESSED_MESSAGE = re.compile(r'^Suppressed \'([a-z0-9-]+)\' \(from li
 
 def get_noqa_suppressions(file_contents):
     """
-    Finds all pep8/flake8 suppression messages
+    Finds all pycodestyle/flake8 suppression messages
 
     :param file_contents:
         A list of file lines

--- a/prospector/tools/__init__.py
+++ b/prospector/tools/__init__.py
@@ -2,11 +2,11 @@
 from prospector.exceptions import FatalProspectorException
 from prospector.tools.base import ToolBase
 from prospector.tools.dodgy import DodgyTool
-from prospector.tools.pep8 import Pep8Tool
+from prospector.tools.pycodestyle import Pep8Tool
 from prospector.tools.pyflakes import PyFlakesTool
 from prospector.tools.pylint import PylintTool
 from prospector.tools.mccabe import McCabeTool
-from prospector.tools.pep257 import Pep257Tool
+from prospector.tools.pydocstyle import Pep257Tool
 from prospector.tools.profile_validator import ProfileValidationTool
 
 
@@ -39,9 +39,9 @@ TOOLS = {
     'dodgy': DodgyTool,
     'mccabe': McCabeTool,
     'pyflakes': PyFlakesTool,
-    'pep8': Pep8Tool,
+    'pycodestyle': Pep8Tool,
     'pylint': PylintTool,
-    'pep257': Pep257Tool,
+    'pydocstyle': Pep257Tool,
     'profile-validator': ProfileValidationTool,
     'frosted': _optional_tool('frosted'),
     'vulture': _optional_tool('vulture'),
@@ -53,8 +53,8 @@ DEFAULT_TOOLS = (
     'dodgy',
     'mccabe',
     'pyflakes',
-    'pep8',
+    'pycodestyle',
     'pylint',
-    'pep257',
+    'pydocstyle',
     'profile-validator'
 )

--- a/prospector/tools/base.py
+++ b/prospector/tools/base.py
@@ -10,7 +10,7 @@ class ToolBase(object):
     def configure(self, prospector_config, found_files):
         """
         Tools have their own way of being configured from configuration files
-        on the current path - for example, a .pep8rc file. Prospector will use
+        on the current path - for example, a .pycodestylerc file. Prospector will use
         its own configuration settings unless this method discovers some
         tool-specific configuration that should be used instead.
 

--- a/prospector/tools/pycodestyle/__init__.py
+++ b/prospector/tools/pycodestyle/__init__.py
@@ -7,10 +7,10 @@ from pycodestyle import StyleGuide, BaseReport, register_check, PROJECT_CONFIG
 from pep8ext_naming import NamingChecker
 
 try:
-    # for pep8 <= 1.5.7
+    # for pycodestyle <= 1.5.7
     from pycodestyle import DEFAULT_CONFIG as USER_CONFIG
 except ImportError:
-    # for pep8 >= 1.6.0
+    # for pycodestyle >= 1.6.0
     from pycodestyle import USER_CONFIG
 
 from prospector.message import Location, Message
@@ -35,7 +35,7 @@ class ProspectorReport(BaseReport):
             check,
         )
         if code is None:
-            # The error pep8 found is being ignored, let's move on.
+            # The error pycodestyle found is being ignored, let's move on.
             return
         else:
             # Get a clean copy of the message text without the code embedded.
@@ -54,7 +54,7 @@ class ProspectorReport(BaseReport):
             character=(offset + 1),
         )
         message = Message(
-            source='pep8',
+            source='pycodestyle',
             code=code,
             location=location,
             message=text,
@@ -80,7 +80,7 @@ class ProspectorStyleGuide(StyleGuide):
         if super(ProspectorStyleGuide, self).excluded(filename, parent):
             return True
 
-        # If the file survived pep8's exclusion rules, check it against
+        # If the file survived pycodestyle's exclusion rules, check it against
         # prospector's patterns.
         if os.path.isdir(os.path.join(self._files.rootpath, filename)):
             return False
@@ -102,25 +102,25 @@ class Pep8Tool(ToolBase):
         # 'none' means we ignore any external config, so just carry on
         use_config = False
 
-        if prospector_config.use_external_config('pep8'):
+        if prospector_config.use_external_config('pycodestyle'):
             use_config = True
 
             paths = [os.path.join(found_files.rootpath, name) for name in PROJECT_CONFIG]
             paths.append(USER_CONFIG)
-            ext_loc = prospector_config.external_config_location('pep8')
+            ext_loc = prospector_config.external_config_location('pycodestyle')
             if ext_loc is not None:
                 paths = [ext_loc] + paths
 
             for conf_path in paths:
                 if os.path.exists(conf_path) and os.path.isfile(conf_path):
-                    # this file exists - but does it have pep8 config in it?
-                    header = re.compile(r'\[pep8\]')
+                    # this file exists - but does it have pycodestyle config in it?
+                    header = re.compile(r'\[pycodestyle\]')
                     with open(conf_path) as conf_file:
                         if any([header.search(line) for line in conf_file.readlines()]):
                             external_config = conf_path
                             break
 
-        # Instantiate our custom pep8 checker.
+        # Instantiate our custom pycodestyle checker.
         self.checker = ProspectorStyleGuide(
             paths=list(found_files.iter_package_paths()),
             found_files=found_files,
@@ -130,15 +130,15 @@ class Pep8Tool(ToolBase):
         if not use_config or external_config is None:
             configured_by = None
             # This means that we don't have existing config to use.
-            # Make sure pep8's code ignores are fully reset to zero before
+            # Make sure pycodestyle's code ignores are fully reset to zero before
             # adding prospector-flavoured configuration.
             # pylint: disable=attribute-defined-outside-init
             self.checker.options.select = ()
-            self.checker.options.ignore = tuple(prospector_config.get_disabled_messages('pep8'))
+            self.checker.options.ignore = tuple(prospector_config.get_disabled_messages('pycodestyle'))
 
-            if 'max-line-length' in prospector_config.tool_options('pep8'):
+            if 'max-line-length' in prospector_config.tool_options('pycodestyle'):
                 self.checker.options.max_line_length = \
-                    prospector_config.tool_options('pep8')['max-line-length']
+                    prospector_config.tool_options('pycodestyle')['max-line-length']
         else:
             configured_by = "Configuration found at %s" % external_config
 
@@ -155,5 +155,5 @@ class Pep8Tool(ToolBase):
         return report.get_messages()
 
 
-# Load pep8ext_naming into pep8's configuration.
+# Load pep8ext_naming into pycodestyle's configuration.
 register_check(NamingChecker)

--- a/prospector/tools/pydocstyle/__init__.py
+++ b/prospector/tools/pydocstyle/__init__.py
@@ -19,7 +19,7 @@ class Pep257Tool(ToolBase):
         self.ignore_codes = ()
 
     def configure(self, prospector_config, found_files):
-        self.ignore_codes = prospector_config.get_disabled_messages('pep257')
+        self.ignore_codes = prospector_config.get_disabled_messages('pydocstyle')
 
     def run(self, found_files):
         messages = []
@@ -43,7 +43,7 @@ class Pep257Tool(ToolBase):
                         absolute_path=True,
                     )
                     message = Message(
-                        source='pep257',
+                        source='pydocstyle',
                         code=error.code,
                         location=location,
                         message=error.message.partition(':')[2].strip(),
@@ -51,16 +51,16 @@ class Pep257Tool(ToolBase):
                     messages.append(message)
             except CouldNotHandleEncoding as err:
                 messages.append(make_tool_error_message(
-                    code_file, 'pep257', 'D000',
+                    code_file, 'pydocstyle', 'D000',
                     message='Could not handle the encoding of this file: %s' % err.encoding
                 ))
                 continue
             except AllError as exc:
-                # pep257's Parser.parse_all method raises AllError when an
+                # pydocstyle's Parser.parse_all method raises AllError when an
                 # attempt to analyze the __all__ definition has failed.  This
                 # occurs when __all__ is too complex to be parsed.
                 messages.append(make_tool_error_message(
-                    code_file, 'pep257', 'D000',
+                    code_file, 'pydocstyle', 'D000',
                     line=1, character=0,
                     message=exc.args[0]
                 ))

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     zip_safe=False,
     description='Prospector: python static analysis tool',
     long_description=_LONG_DESCRIPTION,
-    keywords='pylint pyflakes pep8 mccabe frosted prospector static code analysis',
+    keywords='pylint pyflakes pycodestyle pydocstyle mccabe frosted prospector static code analysis',
     classifiers=_CLASSIFIERS,
     package_data=_PACKAGE_DATA,
     include_package_data=True,

--- a/tests/profiles/profiles/inheritance/pycodestyle/base.yaml
+++ b/tests/profiles/profiles/inheritance/pycodestyle/base.yaml
@@ -1,2 +1,2 @@
-pep8:
+pycodestyle:
   none: true

--- a/tests/profiles/profiles/inheritance/pycodestyle/start.yaml
+++ b/tests/profiles/profiles/inheritance/pycodestyle/start.yaml
@@ -1,5 +1,5 @@
 inherits:
   - base
 
-pep8:
+pycodestyle:
   full: true

--- a/tests/profiles/profiles/pycodestyle_and_pylint_disabled.yaml
+++ b/tests/profiles/profiles/pycodestyle_and_pylint_disabled.yaml
@@ -1,5 +1,5 @@
 inherits:
   - pylint_disabled
 
-pep8:
+pycodestyle:
   run: false

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -42,7 +42,7 @@ class TestProfileParsing(ProfileTestBase):
     def test_disable_tool(self):
         profile = ProspectorProfile.load('pylint_disabled', self._profile_path)
         self.assertFalse(profile.is_tool_enabled('pylint'))
-        self.assertTrue(profile.is_tool_enabled('pep8') is None)
+        self.assertTrue(profile.is_tool_enabled('pycodestyle') is None)
 
 
 class TestProfileInheritance(ProfileTestBase):
@@ -61,9 +61,9 @@ class TestProfileInheritance(ProfileTestBase):
         self.assertEqual(['I0002', 'I0003', 'raw-checker-failed'], disable)
 
     def test_disable_tool_inheritance(self):
-        profile = ProspectorProfile.load('pep8_and_pylint_disabled', self._profile_path)
+        profile = ProspectorProfile.load('pycodestyle_and_pylint_disabled', self._profile_path)
         self.assertFalse(profile.is_tool_enabled('pylint'))
-        self.assertFalse(profile.is_tool_enabled('pep8'))
+        self.assertFalse(profile.is_tool_enabled('pycodestyle'))
 
     def test_precedence(self):
         profile = self._load('precedence')
@@ -84,9 +84,9 @@ class TestProfileInheritance(ProfileTestBase):
                                                  forced_inherits=['doc_warnings', 'no_member_warnings']
         )
         self.assertDictEqual(profile.pylint, high_strictness.pylint)
-        self.assertDictEqual(profile.pep8, high_strictness.pep8)
+        self.assertDictEqual(profile.pycodestyle, high_strictness.pycodestyle)
         self.assertDictEqual(profile.pyflakes, high_strictness.pyflakes)
 
-    def test_pep8_inheritance(self):
-        profile = self._load('pep8')
-        self.assertTrue(profile.is_tool_enabled('pep8'))
+    def test_pycodestyle_inheritance(self):
+        profile = self._load('pycodestyle')
+        self.assertTrue(profile.is_tool_enabled('pycodestyle'))


### PR DESCRIPTION
Addresses #222 

The first commit simply replace all occurrences of `pep8` by `pycodestyle` and `pep257` by `pydocstyle`.
Of course, it will break the config files for everybody: to be released as a major change. If we want to make it minor, we should allow both versions in command line options and configuration file options. I will add notes in the diff to where I think this could be done.