### PR TITLE
MyPy: Add the `check-untyped-defs` option for mypy.

### DIFF
--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -397,6 +397,9 @@ The available options are:
 | mypy           | use-dmypy              | Use mypy daemon (mypy server) for faster     |
 |                |                        | checks                                       |
 +----------------+------------------------+----------------------------------------------+
+| mypy           | check-untyped-defs     |Type check the interior of functions without  |
+|                |                        |type annotations                              |
++----------------+------------------------+----------------------------------------------+
 | bandit         | config                 | configuration filename                       |
 +----------------+------------------------+----------------------------------------------+
 | bandit         | profile                | profile to use                               |

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -21,6 +21,7 @@ VALID_OPTIONS = LIST_OPTIONS + [
     "python-2-mode",
     "python-version",
     "namespace-packages",
+    "check-untyped-defs",
 ]
 
 
@@ -90,6 +91,7 @@ class MypyTool(ToolBase):
         python_version = options.get("python-version", None)
         strict_optional = options.get("strict-optional", False)
         namespace_packages = options.get("namespace-packages", False)
+        check_untyped_defs = options.get("check-untyped-defs", False)
 
         self.options.append(f"--follow-imports={follow_imports}")
 
@@ -116,6 +118,9 @@ class MypyTool(ToolBase):
 
         if namespace_packages:
             self.options.append("--namespace-packages")
+
+        if check_untyped_defs:
+            self.options.append("--check-untyped-defs")
 
         for list_option in LIST_OPTIONS:
             for entry in options.get(list_option, []):


### PR DESCRIPTION
## Description

* Add the ability to specify `check-untyped-defs` in the options section for mypy.

## Related Issue

Feature request: https://github.com/landscapeio/prospector/issues/628

## Motivation and Context

It is not required, but helping with better code quality is excellent.

## How Has This Been Tested?

The protocol followed has been: 
- Create a file with a function without types
- Run the current prospector version. 
- Get the message `"By default, the bodies of untyped functions are not checked. Consider using --check-untyped-defs  [annotation-unchecked]"`
- Apply the changes from the PR. 
- Add the option `check-untyped-defs` in the `prospector.yaml` such as:
```
mypy:
  run: true
  options:
    ignore-missing-imports: true
    check-untyped-defs: true
```

- Install it locally with `python3 install -e .` 
- Rerun, the prospector. 
- Get correct type inferences and checks.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [x] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All existing passing tests passed.
- [ ] All new and existing tests passed.
