### PR TITLE
Doc fix: Use hyphen to install prospector with mypy and bandit in pre-commit

### DIFF
--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -44,7 +44,7 @@ them to the hook configuration like so::
         hooks:
         -   id: prospector
             additional_dependencies:
-            - ".[with_mypy,with_bandit]"
+            - ".[with-mypy,with-bandit]"
           - args: [
             '--with-tool=mypy',
             '--with-tool=bandit',
@@ -53,4 +53,4 @@ them to the hook configuration like so::
 
 This is equivalent to running::
 
-    pip install prospector[with_bandit,with_mypy]
+    pip install prospector[with-bandit,with-mypy]


### PR DESCRIPTION
Doc fix to use `-` instead of `_` to install mypy/bandit with prospector in pre-commit.

## Description

See #633. From [this discussion](https://github.com/landscapeio/prospector/issues/624#issuecomment-1600867046) seems to be related to how poetry resolves optional dependencies

## Related Issue

#633

## Motivation and Context

Makes docs clearer.

## How Has This Been Tested?

Used this updated pre-commit config in my own project, which was previously experiencing dependency install issues.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
