### PR TITLE
Limit pylint to <3 while waiting for a new release of ``requirements-detector``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Version 1.11.0
 **New**:
 
 * We dropped support for python 3.7.
+* prospector now support python 3.12 and 3.13.
+* pylint is now set to version 3.0.0 or less, while waiting
+  for a new release of ``requirements-detector`` compatible
+  with pylint 3.0+.
 
 
 Version 1.10.3
@@ -388,7 +392,7 @@ Version 0.12.9
 
 Version 0.12.8
 ---------------
-* Enforece pylint, pyflakes and pycodestyle versions to avoid breaking other dependent tools
+* Enforce pylint, pyflakes and pycodestyle versions to avoid breaking other dependent tools
 * `#242 <https://github.com/PyCQA/prospector/pull/248>`_ Fix absolute path issue with pylint
 * `#234 <https://github.com/PyCQA/prospector/pull/234>`_ Added Python 3.5/3.6 support on build
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2002,4 +2002,4 @@ with-vulture = ["vulture"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "a536355b405c5e530476d40068b30def3d1e231bcd80865b119d8665a7d48f8c"
+content-hash = "e9a0b66267b1a75d3cb127ad12861918698d7adcc88f199a489df5df85e1f0b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prospector"
-version = "1.10.3"
+version = "1.11.0"
 description = "Prospector is a tool to analyse Python code by aggregating the result of other tools."
 authors = ["Carl Crowder <git@carlcrowder.com>"]
 maintainers = ["Carl Crowder <git@carlcrowder.com>",
@@ -38,7 +38,7 @@ prospector = 'prospector.run:main'
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-pylint = ">=2.8.3"
+pylint = ">=2.8.3,<3.0"
 pylint-celery = "0.3"
 pylint-django = "~2.5"
 pylint-plugin-utils = "~0.7"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

That would need to be rebased so we can release 1.10.4 by tagging the middle commit.

<!--- Describe your changes in detail -->

## Related Issue

Closes #641
