### PR TITLE
Fix pkg resources import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,9 @@
 # import os
 # import sys
 
-import pkg_resources
+from importlib import metadata
 
-version = pkg_resources.get_distribution("prospector").version
+version = metadata.distribution("prospector").version
 
 release = ".".join(version.split(".")[:2])
 

--- a/prospector/blender.py
+++ b/prospector/blender.py
@@ -98,7 +98,7 @@ def blend(messages, blend_combos=None):
 
 
 def get_default_blend_combinations():
-    combos = yaml.safe_load(resources.files(__package__).joinpath("blender_combinations.yaml").read_text())
+    combos = yaml.safe_load(resources.read_text(__package__, "blender_combinations.yaml"))
     combos = combos.get("combinations", [])
 
     defaults = []

--- a/prospector/blender.py
+++ b/prospector/blender.py
@@ -5,8 +5,8 @@
 # "Unused Import" warning on the same line. This is obviously redundant, so we
 # remove duplicates.
 from collections import defaultdict
-
 from importlib import resources
+
 import yaml
 
 __all__ = (
@@ -98,7 +98,7 @@ def blend(messages, blend_combos=None):
 
 
 def get_default_blend_combinations():
-    combos = yaml.safe_load(resources.read_text(__name__, "blender_combinations.yaml"))
+    combos = yaml.safe_load(resources.files(__package__).joinpath("blender_combinations.yaml").read_text())
     combos = combos.get("combinations", [])
 
     defaults = []

--- a/prospector/blender.py
+++ b/prospector/blender.py
@@ -6,7 +6,7 @@
 # remove duplicates.
 from collections import defaultdict
 
-import pkg_resources
+from importlib import resources
 import yaml
 
 __all__ = (
@@ -98,7 +98,7 @@ def blend(messages, blend_combos=None):
 
 
 def get_default_blend_combinations():
-    combos = yaml.safe_load(pkg_resources.resource_string(__name__, "blender_combinations.yaml"))
+    combos = yaml.safe_load(resources.read_text(__name__, "blender_combinations.yaml"))
     combos = combos.get("combinations", [])
 
     defaults = []

--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from importlib import metadata
+
 import setoptconf as soc
 
 from prospector.config.datatype import OutputChoice

--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-import pkg_resources
+from importlib import metadata
 import setoptconf as soc
 
 from prospector.config.datatype import OutputChoice
@@ -8,7 +8,7 @@ from prospector.tools import DEFAULT_TOOLS, TOOLS
 
 __all__ = ("build_manager",)
 
-_VERSION = pkg_resources.get_distribution("prospector").version
+_VERSION = metadata.distribution("prospector").version
 
 
 def build_manager():


### PR DESCRIPTION
## Description

The use of pkg_resources is deprecated in favor of its importlib equivalents. Running the pre-commit hook with Python 3.12 fails because pkg_resources cannot be found.

`ModuleNotFoundError: No module named 'pkg_resources'`

## Related Issue
https://github.com/landscapeio/prospector/issues/646

## Motivation and Context

This pull request fixes the error `ModuleNotFoundError: No module named 'pkg_resources'` when ran by pre-commit

## How Has This Been Tested?
Ran all tests with pytest locally

**Failed tests**
```
FAILED tests/profiles/test_profile.py::TestProfileInheritance::test_module_file_inheritance - prospector.profiles.exceptions.ProfileNotFound
FAILED tests/profiles/test_profile.py::TestProfileInheritance::test_module_inheritance - prospector.profiles.exceptions.ProfileNotFound
FAILED tests/tools/pyroma/test_pyroma_tool.py::test_forced_include - assert 12 == 10
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
